### PR TITLE
minor tweaks to prevent linking errors with vtk constructs

### DIFF
--- a/crs_perception/CMakeLists.txt
+++ b/crs_perception/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -26,17 +28,17 @@ find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(PCL REQUIRED)
-find_package(VTK REQUIRED)
+find_package(VTK REQUIRED NO_MODULE)
 
 include_directories(include
   SYSTEM
   ${PCL_INCLUDE_DIRS}
   ${VTK_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/model_to_point_cloud.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} ${VTK_LIBRARIES})
   
 
 add_library(${PROJECT_NAME}_nodes SHARED

--- a/crs_perception/include/crs_perception/model_to_point_cloud.hpp
+++ b/crs_perception/include/crs_perception/model_to_point_cloud.hpp
@@ -24,7 +24,7 @@ namespace crs_perception
     float leaf_size_;
 
     void uniformSampling(vtkSmartPointer<vtkPolyData> polydata, std::size_t n_samples, pcl::PointCloud<pcl::PointXYZ> & cloud_out);
-    inline void randPSurface(vtkPolyData *polydata, std::vector<double> *cumulativeAreas, double totalArea, Eigen::Vector3f& p);
+    inline void randPSurface(vtkSmartPointer<vtkPolyData> polydata, std::vector<double> *cumulativeAreas, double totalArea, Eigen::Vector3f& p);
     inline void randomPointTriangle(float a1, float a2, float a3, float b1, float b2, float b3, float c1, float c2, float c3,
                                     float r1, float r2, Eigen::Vector3f& p);
     inline double uniformDeviate(int seed);

--- a/crs_perception/src/model_to_point_cloud.cpp
+++ b/crs_perception/src/model_to_point_cloud.cpp
@@ -75,7 +75,7 @@ namespace crs_perception
     }
   }
 
-  inline void ModelToPointCloud::randPSurface(vtkPolyData *polydata, std::vector<double> *cumulativeAreas, double totalArea, Eigen::Vector3f& p)
+  inline void ModelToPointCloud::randPSurface(vtkSmartPointer<vtkPolyData> polydata, std::vector<double> *cumulativeAreas, double totalArea, Eigen::Vector3f& p)
   {
     float r = static_cast<float>(uniformDeviate(rand()) * totalArea);
 


### PR DESCRIPTION
I ran into a linking issue related to a library in crs_perception being built as static.  These changes address that