### PR TITLE
Remove outdated descartes_tesseract depend

### DIFF
--- a/crs_motion_planning/package.xml
+++ b/crs_motion_planning/package.xml
@@ -36,7 +36,6 @@
   <depend>descartes_light</depend>
   <depend>descartes_ikfast</depend>
   <depend>descartes_samplers</depend>
-  <depend>descartes_tesseract</depend>
 
   <depend>tf2</depend>
 


### PR DESCRIPTION
The code in descartes_tesseract was removed a while ago. It is now in  tesseract_motion_planners. This was confusing rosdep.