### PR TITLE
Feature motion planning manager

### DIFF
--- a/crs_application/CMakeLists.txt
+++ b/crs_application/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(crs_msgs REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(scxml_core REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 find_package(Eigen3 REQUIRED NO_MODULE)
@@ -42,7 +43,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC)
-ament_target_dependencies(${PROJECT_NAME} rclcpp rclcpp_components crs_msgs)
+ament_target_dependencies(${PROJECT_NAME} rclcpp rclcpp_components crs_msgs tf2_eigen)
 
 add_executable(${PROJECT_NAME}_node src/crs_application.cpp)
 target_link_libraries(${PROJECT_NAME}_node 
@@ -52,7 +53,7 @@ target_include_directories(${PROJECT_NAME}_node PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_node SYSTEM PUBLIC)
-ament_target_dependencies(${PROJECT_NAME}_node rclcpp rclcpp_components crs_msgs)
+ament_target_dependencies(${PROJECT_NAME}_node rclcpp rclcpp_components crs_msgs tf2_eigen)
 
 ##################################
 # install

--- a/crs_application/include/crs_application/common/datatypes.h
+++ b/crs_application/include/crs_application/common/datatypes.h
@@ -36,7 +36,10 @@
 #ifndef INCLUDE_CRS_APPLICATION_COMMON_DATATYPES_H_
 #define INCLUDE_CRS_APPLICATION_COMMON_DATATYPES_H_
 
+#include <vector>
 #include <Eigen/Geometry>
+#include <crs_msgs/msg/process_motion_plan.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
 
 namespace crs_application
 {
@@ -50,12 +53,18 @@ struct ScanAcquisitionResult
 
 struct ProcessToolpathData
 {
-
+  std::vector<geometry_msgs::msg::PoseArray> rasters;
 };
 
+struct MediaChangeMotionPlan
+{
+  trajectory_msgs::msg::JointTrajectory start_traj;
+  trajectory_msgs::msg::JointTrajectory return_traj;
+};
 struct ProcessExecutionData
 {
-
+  std::vector< crs_msgs::msg::ProcessMotionPlan > process_plans;
+  std::vector< MediaChangeMotionPlan > media_change_plans;
 };
 
 struct PartInspectionResult

--- a/crs_application/include/crs_application/task_managers/motion_planning_manager.h
+++ b/crs_application/include/crs_application/task_managers/motion_planning_manager.h
@@ -90,6 +90,7 @@ protected:
 
   // support methods
   common::ActionResult checkPreReq();
+  sensor_msgs::msg::JointState::SharedPtr getCurrentState();
 
   std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<datatypes::ProcessToolpathData> input_ = nullptr;
@@ -101,6 +102,7 @@ protected:
 
   // process data
   std::vector<datatypes::ProcessToolpathData> process_toolpaths_;
+
 };
 
 } /* namespace task_managers */

--- a/crs_application/include/crs_application/task_managers/motion_planning_manager.h
+++ b/crs_application/include/crs_application/task_managers/motion_planning_manager.h
@@ -37,7 +37,10 @@
 #define INCLUDE_CRS_APPLICATION_TASK_MANAGERS_MOTION_PLANNING_MANAGER_H_
 
 #include <memory>
+#include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
+#include <crs_msgs/srv/call_freespace_motion.hpp>
+#include <crs_msgs/srv/plan_process_motions.hpp>
 #include "crs_application/common/common.h"
 #include "crs_application/common/datatypes.h"
 
@@ -48,7 +51,15 @@ namespace task_managers
 
 struct MotionPlanningConfig
 {
+  double tool_speed;
+  Eigen::Isometry3d offset_pose;
+  double retreat_dist;
+  double approac_dist;
+  std::string tool_frame;
 
+  // media change
+  double media_change_time;             /** @brief secs */
+  Eigen::Isometry3d media_change_pose;  /** @brief in world coordinates */
 };
 
 class MotionPlanningManager
@@ -77,9 +88,19 @@ public:
 
 protected:
 
+  // support methods
+  common::ActionResult checkPreReq();
+
   std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<datatypes::ProcessToolpathData> input_ = nullptr;
+  std::shared_ptr<MotionPlanningConfig> config_ = nullptr;
   datatypes::ProcessExecutionData result_;
+
+  rclcpp::Client<crs_msgs::srv::CallFreespaceMotion>::SharedPtr call_freespace_planning_client_;
+  rclcpp::Client<crs_msgs::srv::PlanProcessMotions>::SharedPtr process_motion_planning_client_;
+
+  // process data
+  std::vector<datatypes::ProcessToolpathData> process_toolpaths_;
 };
 
 } /* namespace task_managers */

--- a/crs_application/package.xml
+++ b/crs_application/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>crs_msgs</depend>  
+  <depend>tf2_eigen</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/crs_application/src/crs_executive.cpp
+++ b/crs_application/src/crs_executive.cpp
@@ -318,15 +318,15 @@ bool CRSExecutive::setupMotionPlanningStates()
 
   st_callbacks_map[motion_planning::PLAN_PROCESS_PATHS] = StateCallbackInfo{
     entry_cb : std::bind(&task_managers::MotionPlanningManager::planProcessPaths, motion_planning_mngr_.get()),
-    async : false};
+    async : true};
 
   st_callbacks_map[motion_planning::PLAN_MEDIA_CHANGES] = StateCallbackInfo{
     entry_cb : std::bind(&task_managers::MotionPlanningManager::planMediaChanges, motion_planning_mngr_.get()),
-    async : false};
+    async : true};
 
   st_callbacks_map[motion_planning::PREVIEW] = StateCallbackInfo{
     entry_cb : std::bind(&task_managers::MotionPlanningManager::showPreview, motion_planning_mngr_.get()),
-    async : false,
+    async : true,
     exit_cb : std::bind(&task_managers::MotionPlanningManager::hidePreview, motion_planning_mngr_.get()),
     on_done_action : ""};
 

--- a/crs_application/src/task_managers/motion_planning_manager.cpp
+++ b/crs_application/src/task_managers/motion_planning_manager.cpp
@@ -206,11 +206,11 @@ common::ActionResult MotionPlanningManager::splitToolpaths()
       new_raster.poses.clear();
       std::copy(raster.poses.begin() + start_idx, raster.poses.begin() + end_idx,
                 std::back_inserter(new_raster.poses));
-      toolpaths_processes.back().rasters.push_back(raster);
+      toolpaths_processes.back().rasters.push_back(new_raster);
 
       // create new toolpath
       toolpaths_processes.resize(toolpaths_processes.size() + 1);
-      start_idx = p_idx;
+      start_idx = end_idx;
     }
 
     // copy remaining segment of raster into toolpath
@@ -219,7 +219,7 @@ common::ActionResult MotionPlanningManager::splitToolpaths()
       new_raster.poses.clear();
       std::copy(raster.poses.begin() + end_idx, raster.poses.end(),
                 std::back_inserter(new_raster.poses));
-      toolpaths_processes.back().rasters.push_back(raster);
+      toolpaths_processes.back().rasters.push_back(new_raster);
     }
   }
 

--- a/crs_application/src/task_managers/motion_planning_manager.cpp
+++ b/crs_application/src/task_managers/motion_planning_manager.cpp
@@ -33,7 +33,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <tf2_eigen/tf2_eigen.h>
+#include <boost/optional.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include "crs_application/common/utils.h"
 #include "crs_application/task_managers/motion_planning_manager.h"
+
+static const double WAIT_SERVICE_DURATION = 2.0; // secs
+static const double WAIT_SERVICE_COMPLETION_PERIOD = 30.0; // secs
+static const std::string CALL_FREESPACE_MOTION_SERVICE = "plan_free_space";
+static const std::string PLAN_PROCESS_MOTIONS_SERVICE = "plan_process_motions";
+static const std::string MANAGER_NAME = "MotionPlanningManager";
 
 namespace crs_application
 {
@@ -53,37 +64,247 @@ MotionPlanningManager::~MotionPlanningManager()
 
 common::ActionResult MotionPlanningManager::init()
 {
-  RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
+  using namespace crs_msgs;
+  call_freespace_planning_client_ = node_->create_client<srv::CallFreespaceMotion>(CALL_FREESPACE_MOTION_SERVICE);
+  process_motion_planning_client_ = node_->create_client<crs_msgs::srv::PlanProcessMotions>(PLAN_PROCESS_MOTIONS_SERVICE);
+
+  // checking clients
+  std::vector<rclcpp::ClientBase*> clients = {call_freespace_planning_client_.get(),
+                                              process_motion_planning_client_.get()};
+  if(std::all_of(clients.begin(), clients.end(),[](rclcpp::ClientBase* c){
+    return c->wait_for_service(std::chrono::duration<float>(WAIT_SERVICE_DURATION));
+  }))
+  {
+    RCLCPP_WARN(node_->get_logger(),"%s: One or more services were not found", MANAGER_NAME.c_str());
+    return false;
+  }
+
   return true;
 }
 
 common::ActionResult MotionPlanningManager::configure(const MotionPlanningConfig& config)
 {
-  RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
+  config_ = std::make_shared<MotionPlanningConfig>(config);
   return true;
 }
 
 common::ActionResult MotionPlanningManager::setInput(const datatypes::ProcessToolpathData& input)
 {
-  RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
+  if(input.rasters.empty())
+  {
+    RCLCPP_ERROR(node_->get_logger(),"%s found no rasters in the process path", MANAGER_NAME.c_str());
+    return false;
+  }
+  input_ = std::make_shared<datatypes::ProcessToolpathData>(input);
+  return true;
+}
+
+
+common::ActionResult MotionPlanningManager::checkPreReq()
+{
+  if(!config_)
+  {
+    common::ActionResult res = { succeeded :false, err_msg: "No configuration has been provided, can not proceed"};
+    RCLCPP_WARN(node_->get_logger(),"%s %s",MANAGER_NAME.c_str(), res.err_msg.c_str());
+  }
+
+  if(!input_)
+  {
+    common::ActionResult res = { succeeded :false, err_msg: "No input data has been provided, can not proceed"};
+    RCLCPP_WARN(node_->get_logger(),"%s %s",MANAGER_NAME.c_str(), res.err_msg.c_str());
+  }
   return true;
 }
 
 common::ActionResult MotionPlanningManager::splitToolpaths()
 {
-  RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
+  common::ActionResult res = checkPreReq();
+  if( !res )
+  {
+    return res;
+  }
+
+  // computing split distance
+  const double split_dist = config_->tool_speed * config_->media_change_time;
+
+  // splitting paths
+  std::vector<datatypes::ProcessToolpathData> toolpaths_processes;
+  double current_dist = 0.0;
+  Eigen::Vector3d p1, p2;
+  toolpaths_processes.resize(1);
+  for(std::size_t r_idx = 0 ; r_idx < input_->rasters.size(); r_idx++)
+  {
+    geometry_msgs::msg::PoseArray& raster = input_->rasters[r_idx];
+    int split_point_idx = -1;
+    for(std::size_t p_idx = 0; p_idx < raster.poses.size() - 1; p_idx++)
+    {
+      p1 = crs_common::toEigen(raster.poses[p_idx].position);
+      p2 = crs_common::toEigen(raster.poses[p_idx + 1].position);
+
+      double d = (p2 - p1).norm();
+      if(current_dist + d > split_dist)
+      {
+        RCLCPP_INFO(node_->get_logger(),"Found split at point %lu of raster %lu",p_idx, r_idx);
+        split_point_idx = p_idx;
+        current_dist = 0;
+        break;
+      }
+      current_dist += d;
+    }
+
+    if(split_point_idx >=0)
+    {
+      std::remove_reference <decltype(raster)>::type new_raster;
+      std::copy(raster.poses.begin(), raster.poses.begin() + split_point_idx,
+                std::back_inserter(new_raster.poses));
+      toolpaths_processes.back().rasters.push_back(new_raster);
+
+      // copying remaining part of raster into a new  process
+      toolpaths_processes.resize(toolpaths_processes.size() + 1);
+      new_raster.poses.clear();
+      std::copy(raster.poses.begin() + split_point_idx + 1, raster.poses.end(),
+                std::back_inserter(new_raster.poses));
+      toolpaths_processes.back().rasters.push_back(new_raster);
+    }
+    else
+    {
+      // no split so copy current raster into current process
+      toolpaths_processes.back().rasters.push_back(raster);
+    }
+  }
+  RCLCPP_INFO(node_->get_logger(),"Split original process into %lu", toolpaths_processes.size());
+  process_toolpaths_ = std::move(toolpaths_processes);
   return true;
 }
 
 common::ActionResult MotionPlanningManager::planProcessPaths()
 {
-  RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
+  using namespace crs_msgs;
+
+  common::ActionResult res = checkPreReq();
+  if( !res )
+  {
+    return res;
+  }
+
+  // copying data into request
+  srv::PlanProcessMotions::Request::SharedPtr req = std::make_shared<srv::PlanProcessMotions::Request>();
+  for(datatypes::ProcessToolpathData& pd : process_toolpaths_)
+  {
+    msg::ToolProcessPath process_path;
+    for(const geometry_msgs::msg::PoseArray& raster : pd.rasters)
+    {
+      process_path.rasters.push_back(raster);
+    }
+    req->process_paths.push_back(process_path);
+  }
+
+  std::shared_future<srv::PlanProcessMotions::Response::SharedPtr> fut = process_motion_planning_client_->async_send_request(
+      req);
+  if (rclcpp::spin_until_future_complete(node_->get_node_base_interface(), fut,
+                                         std::chrono::duration<double>(WAIT_SERVICE_COMPLETION_PERIOD))
+      != rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "%s process planning service error or timeout",MANAGER_NAME.c_str());
+    return false;
+  }
+
+  if(!fut.get()->succeeded)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "%s process planning failed",MANAGER_NAME.c_str());
+  }
+
+  // saving process plans
+  result_.process_plans = fut.get()->plans;
   return true;
 }
 
 common::ActionResult MotionPlanningManager::planMediaChanges()
 {
   RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
+  using namespace crs_msgs::srv;
+
+  common::ActionResult res = checkPreReq();
+  if( !res )
+  {
+    return res;
+  }
+
+  result_.media_change_plans.clear();
+  if(result_.process_plans.size() < 2)
+  {
+    RCLCPP_INFO(node_->get_logger(),"%s no media change needed", MANAGER_NAME.c_str());
+    return true;
+  }
+
+  CallFreespaceMotion::Request::SharedPtr req = std::make_shared<CallFreespaceMotion::Request>();
+  req->target_link = config_->tool_frame;
+  geometry_msgs::msg::Pose pose_msg = tf2::toMsg(config_->media_change_pose);
+  std::tie(req->goal_pose.translation.x, req->goal_pose.translation.y,
+           req->goal_pose.translation.z ) = std::make_tuple(pose_msg.position.x,
+                                                            pose_msg.position.y,
+                                                            pose_msg.position.z);
+  req->goal_pose.rotation = pose_msg.orientation;
+  req->execute = false;
+
+
+  auto call_planning = [this](const std::string& plan_name, CallFreespaceMotion::Request::SharedPtr req) ->
+      boost::optional<trajectory_msgs::msg::JointTrajectory>
+    {
+      std::shared_future<CallFreespaceMotion::Response::SharedPtr> fut = call_freespace_planning_client_->async_send_request(
+          req);
+
+      if (rclcpp::spin_until_future_complete(node_->get_node_base_interface(), fut,
+                                             std::chrono::duration<double>(WAIT_SERVICE_COMPLETION_PERIOD))
+          != rclcpp::executor::FutureReturnCode::SUCCESS)
+      {
+        RCLCPP_ERROR(node_->get_logger(), "%s freespace planning service for '%s' move error or timeout",MANAGER_NAME.c_str(),
+                     plan_name.c_str());
+        return boost::none;
+      }
+
+      if(!fut.get()->success)
+      {
+        RCLCPP_ERROR(node_->get_logger(), "%s freespace planning for media change '%s' move failed, %s",MANAGER_NAME.c_str(),
+                     plan_name.c_str(), fut.get()->message.c_str());
+        return boost::none;
+      }
+
+      RCLCPP_INFO(node_->get_logger(), "%s freespace planning for media change '%s' move succeeded",MANAGER_NAME.c_str(),
+                   plan_name.c_str());
+
+      return fut.get()->output_trajectory;
+    };
+
+  for(std::size_t i = 0 ; i < result_.process_plans.size() - 1; i++)
+  {
+    datatypes::MediaChangeMotionPlan media_change_plan;
+    const trajectory_msgs::msg::JointTrajectory& traj  = result_.process_plans[i].end;
+    req->joint_names = traj.joint_names;
+    req->start_position = traj.points.back();
+
+    // calling freespace motion planning to media change position
+    boost::optional<trajectory_msgs::msg::JointTrajectory> opt = call_planning("START", req);
+    if(!opt.is_initialized())
+    {
+      return false;
+    }
+    media_change_plan.start_traj = opt.get();
+
+    // free space motion planning for return move
+    req->start_position = media_change_plan.start_traj.points.back();
+    req->goal_position = media_change_plan.start_traj.points.front();
+    opt = call_planning("RETURN", req);
+    if(!opt.is_initialized())
+    {
+      return false;
+    }
+    media_change_plan.return_traj = opt.get();
+
+    // saving plan
+    result_.media_change_plans.push_back(media_change_plan);
+  }
+
   return true;
 }
 

--- a/crs_application/src/task_managers/motion_planning_manager.cpp
+++ b/crs_application/src/task_managers/motion_planning_manager.cpp
@@ -221,7 +221,6 @@ common::ActionResult MotionPlanningManager::planProcessPaths()
 
 common::ActionResult MotionPlanningManager::planMediaChanges()
 {
-  RCLCPP_WARN(node_->get_logger(),"%s not implemented yet",__PRETTY_FUNCTION__);
   using namespace crs_msgs::srv;
 
   common::ActionResult res = checkPreReq();
@@ -246,7 +245,7 @@ common::ActionResult MotionPlanningManager::planMediaChanges()
                                                             pose_msg.position.z);
   req->goal_pose.rotation = pose_msg.orientation;
   req->execute = false;
-
+  req->num_steps = 0; // planner should use default
 
   auto call_planning = [this](const std::string& plan_name, CallFreespaceMotion::Request::SharedPtr req) ->
       boost::optional<trajectory_msgs::msg::JointTrajectory>

--- a/crs_motion_planning/src/freespace_planning_server.cpp
+++ b/crs_motion_planning/src/freespace_planning_server.cpp
@@ -1,3 +1,6 @@
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <rclcpp_action/rclcpp_action.hpp>
@@ -25,7 +28,24 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
-static const std::vector<double> COEFFICIENTS {10, 10, 10, 10, 10, 10};
+static const std::vector<double> DEFAULT_COEFFICIENTS {10, 10, 10, 10, 10, 10};
+static const std::string RESOURCES_PACKAGE_NAME = "crs_support";
+static const std::string DEFAULT_URDF_PATH = "urdf/crs.urdf";
+static const std::string DEFAULT_SRDF_PATH = "urdf/ur10e_robot.srdf";
+
+static const std::string FREESPACE_MOTION_PLANNING_SERVICE = "plan_freespace_motion";
+static const std::string FREESPACE_TRAJECTORY_TOPIC = "planned_freespace_trajectory";
+static const std::string JOINT_STATES_TOPIC = "joint_states";
+
+namespace param_names
+{
+  static const std::string URDF_PATH = "urdf_path";
+  static const std::string SRDF_PATH = "srdf_path";
+  static const std::string ROOT_LINK_FRAME = "base_link_frame";
+  static const std::string MANIPULATOR_GROUP = "manipulator_group";
+  static const std::string NUM_STEPS = "num_steps";
+  static const std::string CART_WEIGHT_COEFFS = "cartesian_coeffs";
+}
 
 void tesseractRosutilsToMsg(trajectory_msgs::msg::JointTrajectory& traj_msg,
                               const std::vector<std::string>& joint_names,
@@ -62,35 +82,69 @@ public:
   PlanningServer()
     : Node("planning_server_node")
   {
+    namespace fs = boost::filesystem;
+
     // ROS parameters
-    this->declare_parameter("urdf_path", ament_index_cpp::get_package_share_directory("crs_support") + "/urdf/crs.urdf");
-    this->declare_parameter("srdf_path", ament_index_cpp::get_package_share_directory("crs_support") + "/urdf/ur10e_robot.srdf");
-    this->declare_parameter("base_link_frame", "world");
-    this->declare_parameter("manipulator_group", "manipulator");
-    this->declare_parameter("num_steps", 200);
+    this->declare_parameter(param_names::URDF_PATH, (fs::path(ament_index_cpp::get_package_share_directory(RESOURCES_PACKAGE_NAME)) /
+       fs::path(DEFAULT_URDF_PATH)).string());
+
+    this->declare_parameter(param_names::SRDF_PATH, (fs::path(ament_index_cpp::get_package_share_directory(RESOURCES_PACKAGE_NAME)) /
+                            fs::path(DEFAULT_SRDF_PATH)).string());
+
+    this->declare_parameter(param_names::ROOT_LINK_FRAME, "world");
+    this->declare_parameter(param_names::MANIPULATOR_GROUP, "manipulator");
+    this->declare_parameter(param_names::NUM_STEPS, 200);
+    this->declare_parameter(param_names::CART_WEIGHT_COEFFS, DEFAULT_COEFFICIENTS);
 
     // ROS communications
-    plan_service_ = this->create_service<crs_msgs::srv::CallFreespaceMotion>("test_plan", std::bind(&PlanningServer::planService, this, std::placeholders::_1, std::placeholders::_2));
-    traj_publisher_ = this->create_publisher<trajectory_msgs::msg::JointTrajectory>("set_trajectory_test",10);
-    joint_state_listener_ = this->create_subscription<sensor_msgs::msg::JointState>("/joint_states", 2, std::bind(&PlanningServer::jointCallback, this, std::placeholders::_1));
+    plan_service_ = this->create_service<crs_msgs::srv::CallFreespaceMotion>(FREESPACE_MOTION_PLANNING_SERVICE,
+                                                                             std::bind(&PlanningServer::planService,
+                                                                             this, std::placeholders::_1, std::placeholders::_2));
+    traj_publisher_ = this->create_publisher<trajectory_msgs::msg::JointTrajectory>(FREESPACE_TRAJECTORY_TOPIC,10);
+    joint_state_listener_ = this->create_subscription<sensor_msgs::msg::JointState>(JOINT_STATES_TOPIC, 2,
+                                                                              std::bind(&PlanningServer::jointCallback,
+                                                                              this, std::placeholders::_1));
 
+    // openning files
     std::string urdf_path, srdf_path;
-    urdf_path = this->get_parameter("urdf_path").as_string();
-    srdf_path = this->get_parameter("srdf_path").as_string();
-    std::stringstream urdf_xml_string, srdf_xml_string;
-    std::ifstream urdf_in(urdf_path);
-    urdf_xml_string << urdf_in.rdbuf();
-    std::ifstream srdf_in(srdf_path);
-    srdf_xml_string << srdf_in.rdbuf();
+    urdf_path = this->get_parameter(param_names::URDF_PATH).as_string();
+    srdf_path = this->get_parameter(param_names::SRDF_PATH).as_string();
+    std::vector<std::string> file_paths = {urdf_path, srdf_path};
+    std::vector<std::string> file_string_contents;
+    for(const auto& f : file_paths)
+    {
+      std::ifstream ifs(f);
+      if(!ifs.is_open())
+      {
+        throw std::runtime_error(boost::str( boost::format("File '%s' could not be opened" ) % f));
+      }
+      std::stringstream ss;
+      ss << ifs.rdbuf();
+      file_string_contents.push_back(ss.str());
+    }
 
+    const std::string urdf_content = file_string_contents[0];
+    const std::string srdf_content = file_string_contents[1];
+
+    // initializing planning
     tesseract_local_ = std::make_shared<tesseract::Tesseract>();
     tesseract_scene_graph::ResourceLocator::Ptr locator = std::make_shared<tesseract_rosutils::ROSResourceLocator>();
-    tesseract_local_->init(urdf_xml_string.str(), srdf_xml_string.str(), locator);
+    tesseract_local_->init(urdf_content, srdf_content, locator);
 
-    base_link_frame_ = this->get_parameter("base_link_frame").as_string();
-    manipulator_ = this->get_parameter("manipulator_group").as_string();
+    base_link_frame_ = this->get_parameter(param_names::ROOT_LINK_FRAME).as_string();
+    manipulator_ = this->get_parameter(param_names::MANIPULATOR_GROUP).as_string();
+    default_num_steps_ = this->get_parameter(param_names::NUM_STEPS).as_int();
+    cart_weight_coeffs_ = this->get_parameter(param_names::CART_WEIGHT_COEFFS).as_double_array();
 
-    num_steps_ = this->get_parameter("num_steps").as_int();
+    // verifying joints
+    std::vector<std::string> joint_names = tesseract_local_->getFwdKinematicsManagerConst()->getFwdKinematicSolver(
+        manipulator_)->getJointNames();
+    if(cart_weight_coeffs_.size() < 6)
+    {
+      throw std::runtime_error(boost::str(boost::format("cart coeffs array size (%lu) is less than 6") %
+                                          cart_weight_coeffs_.size() ));
+    }
+
   }
 private:
   void jointCallback(const sensor_msgs::msg::JointState::SharedPtr joint_msg)
@@ -111,18 +165,50 @@ private:
     std::vector<tesseract_motion_planners::Waypoint::Ptr> trgt_wypts;
 
     // Define initial waypoint
-    tesseract_motion_planners::JointWaypoint::Ptr joint_init_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(curr_joint_state_.position, curr_joint_state_.name);
-    joint_init_waypoint->setIsCritical(false);
+    tesseract_motion_planners::JointWaypoint::Ptr joint_init_waypoint;
+    if(request->start_position.positions.empty())
+    {
+      //use current position when it was not specified in the request
+      joint_init_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(
+          curr_joint_state_.position, curr_joint_state_.name);
+    }
+    else
+    {
+      if(request->start_position.positions.size() < joint_names.size())
+      {
+        response->message = boost::str(boost::format("start position (%lu) has fewer joints than the required number of %lu") %
+                                       request->start_position.positions.size() % joint_names.size());
+        response->success = false;
+        RCLCPP_ERROR(this->get_logger(),response->message.c_str());
+        return;
+      }
+      joint_init_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(
+          request->start_position.positions, request->joint_names);
+    }
+
+    joint_init_waypoint->setIsCritical(true);
 
     // Define goal waypoint
-    Eigen::Vector3d goal_pose(request->goal_pose.translation.x, request->goal_pose.translation.y, request->goal_pose.translation.z);
-    Eigen::Quaterniond goal_ori(request->goal_pose.rotation.w, request->goal_pose.rotation.x, request->goal_pose.rotation.y, request->goal_pose.rotation.z);
-    tesseract_motion_planners::CartesianWaypoint::Ptr goal_waypoint = std::make_shared<tesseract_motion_planners::CartesianWaypoint>(goal_pose, goal_ori);
+    tesseract_motion_planners::Waypoint::Ptr goal_waypoint;
+    if(request->goal_position.positions.empty())
+    {
+      Eigen::Vector3d goal_pose(request->goal_pose.translation.x, request->goal_pose.translation.y, request->goal_pose.translation.z);
+      Eigen::Quaterniond goal_ori(request->goal_pose.rotation.w, request->goal_pose.rotation.x, request->goal_pose.rotation.y, request->goal_pose.rotation.z);
+      tesseract_motion_planners::CartesianWaypoint::Ptr cart_goal_waypoint = std::make_shared<tesseract_motion_planners::CartesianWaypoint>(goal_pose, goal_ori);
 
-    goal_waypoint->setIsCritical(true);
-    Eigen::VectorXd coeffs(6);
-    coeffs << COEFFICIENTS[0], COEFFICIENTS[1], COEFFICIENTS[2], COEFFICIENTS[3], COEFFICIENTS[4], COEFFICIENTS[5];
-    goal_waypoint->setCoefficients(coeffs);
+      cart_goal_waypoint->setIsCritical(true);
+
+      Eigen::VectorXd coeffs = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(cart_weight_coeffs_.data(), 6);
+      cart_goal_waypoint->setCoefficients(coeffs);
+      goal_waypoint = cart_goal_waypoint;
+      RCLCPP_INFO(this->get_logger(),"Planning FreeSpace motion to cartesian goal");
+    }
+    else
+    {
+      goal_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(
+                request->goal_position.positions, request->joint_names);
+      RCLCPP_INFO(this->get_logger(),"Planning FreeSpace motion to joint goal");
+    }
 
     // Add waypoints
     trgt_wypts.push_back(joint_init_waypoint);
@@ -132,13 +218,14 @@ private:
     traj_pc->target_waypoints = trgt_wypts;
 
     // Various freespace configuration settings
-    traj_pc->num_steps = num_steps_;
+    traj_pc->num_steps = request->num_steps == 0 ? default_num_steps_ :  request->num_steps;;
     traj_pc->smooth_velocities = true;
     traj_pc->smooth_accelerations = true;
     traj_pc->smooth_jerks = true;
     traj_pc->longest_valid_segment_length = 0.1;
     traj_pc->init_type = trajopt::InitInfo::STATIONARY;
 
+    // TODO: Make these values into configurable parameters read from yaml
     tesseract_motion_planners::CollisionConstraintConfig tesseract_collision_const_config;
     tesseract_collision_const_config.safety_margin = 0.01;
     tesseract_collision_const_config.coeff = 20;
@@ -148,7 +235,7 @@ private:
     tesseract_collision_cost_config.enabled = false;
     traj_pc->collision_cost_config = tesseract_collision_cost_config;
 
-    // Setup and solve trajopt motoin plannner
+    // Setup and solve trajopt motion plan
     tesseract_motion_planners::TrajOptMotionPlanner traj_motion_planner;
     tesseract_motion_planners::PlannerResponse plan_resp;
     traj_motion_planner.setConfiguration(traj_pc);
@@ -172,6 +259,7 @@ private:
     }
 
     response->output_trajectory = cumulative_joint_trajectory;
+    response->message = plan_resp.status.message();
     if (plan_resp.status.value() == 0)
     {
       response->success = true;
@@ -179,8 +267,8 @@ private:
     else
     {
       response->success = false;
+      RCLCPP_ERROR(this->get_logger(),response->message.c_str());
     }
-    response->message = plan_resp.status.message();
 
     if (request->execute && response->success)
     {
@@ -198,8 +286,8 @@ private:
 
   std::string base_link_frame_;
   std::string manipulator_;
-
-  int num_steps_;
+  int default_num_steps_;
+  std::vector<double> cart_weight_coeffs_;
 };
 
 

--- a/crs_motion_planning/src/freespace_planning_server.cpp
+++ b/crs_motion_planning/src/freespace_planning_server.cpp
@@ -166,7 +166,7 @@ private:
 
     // Define initial waypoint
     tesseract_motion_planners::JointWaypoint::Ptr joint_init_waypoint;
-    if(request->start_position.positions.empty())
+    if(request->start_position.position.empty())
     {
       //use current position when it was not specified in the request
       joint_init_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(
@@ -174,23 +174,23 @@ private:
     }
     else
     {
-      if(request->start_position.positions.size() < joint_names.size())
+      if(request->start_position.position.size() < joint_names.size())
       {
         response->message = boost::str(boost::format("start position (%lu) has fewer joints than the required number of %lu") %
-                                       request->start_position.positions.size() % joint_names.size());
+                                       request->start_position.position.size() % joint_names.size());
         response->success = false;
         RCLCPP_ERROR(this->get_logger(),response->message.c_str());
         return;
       }
       joint_init_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(
-          request->start_position.positions, request->joint_names);
+          request->start_position.position, request->start_position.name);
     }
 
     joint_init_waypoint->setIsCritical(true);
 
     // Define goal waypoint
     tesseract_motion_planners::Waypoint::Ptr goal_waypoint;
-    if(request->goal_position.positions.empty())
+    if(request->goal_position.position.empty())
     {
       Eigen::Vector3d goal_pose(request->goal_pose.translation.x, request->goal_pose.translation.y, request->goal_pose.translation.z);
       Eigen::Quaterniond goal_ori(request->goal_pose.rotation.w, request->goal_pose.rotation.x, request->goal_pose.rotation.y, request->goal_pose.rotation.z);
@@ -206,7 +206,7 @@ private:
     else
     {
       goal_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(
-                request->goal_position.positions, request->joint_names);
+                request->goal_position.position, request->goal_position.name);
       RCLCPP_INFO(this->get_logger(),"Planning FreeSpace motion to joint goal");
     }
 

--- a/crs_msgs/srv/CallFreespaceMotion.srv
+++ b/crs_msgs/srv/CallFreespaceMotion.srv
@@ -6,6 +6,8 @@ sensor_msgs/JointState start_position 	# leave empty to use current position
 sensor_msgs/JointState goal_position    # looks into this one first
 geometry_msgs/Transform goal_pose		# use this one when 'goal_position' is empty
 
+int32 num_steps							# Set to 0 in order to use default
+
 bool execute
 ---
 trajectory_msgs/JointTrajectory output_trajectory

--- a/crs_msgs/srv/CallFreespaceMotion.srv
+++ b/crs_msgs/srv/CallFreespaceMotion.srv
@@ -1,6 +1,11 @@
 string target_link
+
+# start joint position
 sensor_msgs/JointState start_position 	# leave empty to use current position
-geometry_msgs/Transform goal_pose
+
+sensor_msgs/JointState goal_position    # looks into this one first
+geometry_msgs/Transform goal_pose		# use this one when 'goal_position' is empty
+
 bool execute
 ---
 trajectory_msgs/JointTrajectory output_trajectory

--- a/crs_msgs/srv/PlanProcessMotions.srv
+++ b/crs_msgs/srv/PlanProcessMotions.srv
@@ -1,3 +1,4 @@
+string tool_link
 sensor_msgs/JointState start_position
 sensor_msgs/JointState end_position
 geometry_msgs/Pose tool_offset							


### PR DESCRIPTION
This PR implements parts of the motion planning manager to allows calling the process and free-space motion planners as needed.  
- Free-space motion planner node:
  - Can take a joint goal as well.
  - Parameterized cartesian weight coefficients in case it's necessary to tweak those.
  - A few other minor cosmetic changes

NOTE: Previewing the motion plans is somewhat involved and so it will be done in a subsequent PR