### PR TITLE
Add RVIZ panel for application widget

### DIFF
--- a/crs_application/CMakeLists.txt
+++ b/crs_application/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Eigen3 REQUIRED NO_MODULE)
 ##################################
 # build
 ##################################
-add_library(${PROJECT_NAME} 
+add_library(${PROJECT_NAME} SHARED
 	src/crs_executive.cpp 
 	src/task_managers/scan_acquisition_manager.cpp
 	src/task_managers/part_registration_manager.cpp

--- a/crs_gui/CMakeLists.txt
+++ b/crs_gui/CMakeLists.txt
@@ -3,9 +3,11 @@ project(crs_gui VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(pluginlib REQUIRED)
 
 find_package(shape_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(rviz2 REQUIRED)
 
 find_package(crs_area_selection REQUIRED path)
 find_package(crs_msgs REQUIRED)
@@ -41,6 +43,10 @@ set(crs_gui_widget_SOURCES
   src/widgets/state_machine_interface_widget.cpp
 )
 
+set(crs_gui_panel_SOURCES
+  src/application_panel.cpp
+)
+
 # Run the MOC on the Qt-related UIs and headers
 qt5_wrap_ui(crs_gui_UIS_H
   ${crs_gui_UIS}
@@ -50,8 +56,12 @@ qt5_wrap_cpp(crs_gui_widget_MOCS
   ${crs_gui_widget_HEADERS}
 )
 
+qt5_wrap_cpp(crs_gui_panel_MOCS
+  include/${PROJECT_NAME}/application_panel.h
+)
+
 # Qt Widgets
-add_library(${PROJECT_NAME}_widgets
+add_library(${PROJECT_NAME}_widgets SHARED
   ${crs_gui_UIS_H}
   ${crs_gui_widget_MOCS}
   ${crs_gui_widget_SOURCES}
@@ -83,6 +93,17 @@ target_link_libraries(${PROJECT_NAME}_widgets
   crs_area_selection::crs_area_selection_area_selection
   crs_motion_planning::crs_motion_planning_path_processing_utils
 )
+
+# Rviz Panel
+add_library(${PROJECT_NAME}_panels SHARED
+  ${crs_gui_panel_MOCS}
+  ${crs_gui_panel_SOURCES}
+)
+target_link_libraries(${PROJECT_NAME}_panels
+  ${PROJECT_NAME}_widgets
+)
+
+
 ament_target_dependencies(${PROJECT_NAME}_widgets rclcpp shape_msgs std_srvs crs_msgs)
 
 ######################
@@ -124,6 +145,7 @@ target_include_directories(${PROJECT_NAME}_state_machine_interface_demo PUBLIC
 #############
 install(
   TARGETS
+    ${PROJECT_NAME}_panels
     ${PROJECT_NAME}_widgets
     ${PROJECT_NAME}_area_selection_demo
     ${PROJECT_NAME}_part_selection_demo
@@ -153,6 +175,10 @@ install(DIRECTORY ui/
   DESTINATION share/${PROJECT_NAME}/ui
 )
 
+install(
+  FILES plugin_description.xml
+  DESTINATION share/${PROJECT_NAME}
+)
 
 #############
 ## Ament ##
@@ -160,8 +186,11 @@ install(DIRECTORY ui/
 ament_export_dependencies(
     ament_cmake
     crs_area_selection
+    pluginlib
     rclcpp
     shape_msgs
     std_srvs)
+
+pluginlib_export_plugin_description_file(rviz_common plugin_description.xml)
 
 ament_package()

--- a/crs_gui/include/crs_gui/application_panel.h
+++ b/crs_gui/include/crs_gui/application_panel.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CRS_GUI_APPLICATION_PANEL_H
+#define CRS_GUI_APPLICATION_PANEL_H
+
+#include <rviz_common/panel.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace crs_gui
+{
+class CRSApplicationWidget;
+
+/**
+ * @brief Simple RViz panel that wraps the application widget such that can easily
+ * be used within the context of RViz
+ */
+class ApplicationPanel : public rviz_common::Panel
+{
+  Q_OBJECT
+public:
+  ApplicationPanel(QWidget* parent = nullptr);
+
+  virtual void onInitialize() override;
+
+private:
+  rclcpp::Node::SharedPtr node_;
+
+  std::shared_ptr<CRSApplicationWidget> application_widget_;
+};
+}  // namespace crs_gui
+
+#endif

--- a/crs_gui/package.xml
+++ b/crs_gui/package.xml
@@ -17,12 +17,14 @@
   <depend>rclcpp</depend>
   <depend>shape_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>rviz2</depend>
   <depend>crs_msgs</depend>
   <depend>crs_motion_planning</depend>
+  <depend>pluginlib</depend>
   <exec_depend>xterm</exec_depend>
 
   <export>
-<!--    <rviz plugin="${prefix}/plugin_description.xml"/>-->
     <build_type>ament_cmake</build_type>
+    <rviz plugin="${prefix}/plugin_description.xml"/>
   </export>
 </package>

--- a/crs_gui/plugin_description.xml
+++ b/crs_gui/plugin_description.xml
@@ -1,0 +1,8 @@
+<library path="libcrs_gui_panels">
+  <class type="crs_gui::ApplicationPanel"
+         base_class_type="rviz_common::Panel">
+    <description>
+      A panel for running the CRS application
+    </description>
+  </class>
+</library>

--- a/crs_gui/src/application_panel.cpp
+++ b/crs_gui/src/application_panel.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <crs_gui/application_panel.h>
+#include <crs_gui/widgets/crs_application_widget.h>
+#include <QVBoxLayout>
+
+namespace crs_gui
+{
+ApplicationPanel::ApplicationPanel(QWidget* parent)
+  : rviz_common::Panel(parent)
+  , node_(new rclcpp::Node("application_panel_node"))
+  , application_widget_(new CRSApplicationWidget(node_, this))
+{
+}
+
+void ApplicationPanel::onInitialize()
+{
+  QVBoxLayout* layout = new QVBoxLayout();
+  layout->addWidget(application_widget_.get());
+
+  setLayout(layout);
+}
+}  // namespace crs_gui
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(crs_gui::ApplicationPanel, rviz_common::Panel)

--- a/crs_motion_planning/CMakeLists.txt
+++ b/crs_motion_planning/CMakeLists.txt
@@ -47,7 +47,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 
 find_package(yaml-cpp REQUIRED)
 
-add_library(${PROJECT_NAME}_path_processing_utils src/path_processing_utils.cpp)
+add_library(${PROJECT_NAME}_path_processing_utils SHARED src/path_processing_utils.cpp)
 target_include_directories(${PROJECT_NAME}_path_processing_utils PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"
@@ -70,7 +70,7 @@ target_link_libraries(${PROJECT_NAME}_path_processing_utils
   Eigen3::Eigen
   )
 
-add_library(${PROJECT_NAME}_path_planning_utils src/path_planning_utils.cpp)
+add_library(${PROJECT_NAME}_path_planning_utils SHARED src/path_planning_utils.cpp)
 target_include_directories(${PROJECT_NAME}_path_planning_utils PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"


### PR DESCRIPTION
The plugin loads and looks fine in RVIZ. However it still has some issues. When using the RVIZ panel (instead of the widget directly) the state machine monitor only updates when you click query, and it currently crashes when you click load part for some reason. I'm thinking its some sort of threading issue, but I'm proposing merging this into integration since it successfully exports the plugin and loads it at runtime. Then we can figure out what is making it crash when calling ROS interfaces inside RVIZ later.