### PR TITLE
Raster Planning improvments

### DIFF
--- a/crs_application/config/main/crs.yaml
+++ b/crs_application/config/main/crs.yaml
@@ -44,6 +44,7 @@ crs:
     target_frame_id: "world"
     part_file: ""      # relative to known data directory
     toolpath_file: ""  # relative to known data directory
+    toolpath_edge_buffer: 0.15
   part_rework: 
     scan_poses:
       - pose: [-0.869, -0.397, 1.559, -3.1289652, 0.6427091, 3.1099935]

--- a/crs_application/config/main/motion_planning/MP_config.yaml
+++ b/crs_application/config/main/motion_planning/MP_config.yaml
@@ -11,17 +11,19 @@ general:
   max_joint_vel: 0.3
   max_joint_vel_mult: 1.80
   max_surface_dist: 0.15
+  max_rotation_rate: 3.0
   max_joint_acc: 0.8
   add_approach_and_retreat: true
-  minimum_raster_length: 4
-  reachable_radius: 1.25
+  minimum_raster_length: 5
+  reachable_radius: 1.35
   trajopt_verbose_output: false
   combine_strips: true
   global_descartes: true
 descartes:
-  axial_step: 0.4
+  axial_step: 0.1
   collision_safety_margin: 0.00
   additional_tool_offset: [0.0, 0.0, 0.004, 0.0, 0.0, 0.0]
+  joint_min_vals: [-0.1, -0.1, -0.4, -0.1, 0.1, -0.1]
 trajopt_surface:
   smooth_velocities: true
   smooth_accelerations: true
@@ -32,11 +34,15 @@ trajopt_surface:
   waypoints_critical: true
   collision_cost:
     enabled: true
-    buffer_margin: 0.02
+    buffer_margin: 0.03
   special_collision_costs:
     - link1: "robot_stand"
       link2: "upper_arm_link"
       distance: 0.03
+      cost: 10.0
+    - link1: "eoat_link"
+      link2: "forearm_link"
+      distance: 0.05
       cost: 10.0
   collision_constraint:
     enabled: false
@@ -54,12 +60,16 @@ ompl:
   collision_safety_margin: 0.01
   planning_time: 120.0
   simplify: true
-  range: 0.25
-  num_threads: 4
+  # range: 0.25
+  range: 0.15
+  num_threads: 8
   max_solutions: 10
   default_n_output_states: 20
-  longest_valid_segment_fraction: 0.01
+  longest_valid_segment_fraction: 0.05
   longest_valid_segment_length: 0.5
+  retry_failure: true
+  retry_distance: 0.002
+  retry_at_zero: true
 trajopt_freespace:
   smooth_velocities: true
   smooth_accelerations: true

--- a/crs_application/config/main/motion_planning/MP_config.yaml
+++ b/crs_application/config/main/motion_planning/MP_config.yaml
@@ -60,7 +60,6 @@ ompl:
   collision_safety_margin: 0.01
   planning_time: 120.0
   simplify: true
-  # range: 0.25
   range: 0.15
   num_threads: 8
   max_solutions: 10

--- a/crs_application/config/main/motion_planning/MP_config.yaml
+++ b/crs_application/config/main/motion_planning/MP_config.yaml
@@ -14,6 +14,7 @@ general:
   max_joint_acc: 0.8
   add_approach_and_retreat: true
   minimum_raster_length: 4
+  reachable_radius: 1.25
   trajopt_verbose_output: false
   combine_strips: true
   global_descartes: true

--- a/crs_application/config/swri/crs.yaml
+++ b/crs_application/config/swri/crs.yaml
@@ -44,6 +44,7 @@ crs:
     target_frame_id: "world"
     part_file: ""      # relative to known data directory
     toolpath_file: ""  # relative to known data directory
+    toolpath_edge_buffer: 0.15
   part_rework: 
     scan_poses:
       - pose: [-0.869, -0.397, 1.559, -3.1289652, 0.6427091, 3.1099935]

--- a/crs_application/config/swri/motion_planning/MP_config.yaml
+++ b/crs_application/config/swri/motion_planning/MP_config.yaml
@@ -9,11 +9,13 @@ general:
   tool0_frame: "tool0"
   required_tool_vel: true
   max_joint_vel: 0.3
-  max_joint_vel_mult: 1.5
+  max_joint_vel_mult: 1.80
   max_surface_dist: 0.15
+  max_rotation_rate: 3.0
   max_joint_acc: 0.8
   add_approach_and_retreat: true
   minimum_raster_length: 2
+  reachable_radius: 2.5
   trajopt_verbose_output: false
   combine_strips: true
   global_descartes: true
@@ -21,6 +23,7 @@ descartes:
   axial_step: 0.5 # Pi/36
   collision_safety_margin: 0.00
   additional_tool_offset: [0.0, 0.0, 0.005, 0.0, 0.0, 0.0]
+  joint_min_vals: [-0.1, -0.1, -0.4, -0.1, 0.1, -0.1]
 trajopt_surface:
   smooth_velocities: false
   smooth_accelerations: false
@@ -67,6 +70,9 @@ ompl:
   default_n_output_states: 20
   longest_valid_segment_fraction: 0.01
   longest_valid_segment_length: 0.5
+  retry_failure: true
+  retry_distance: 0.002
+  retry_at_zero: true
 trajopt_freespace:
   smooth_velocities: true
   smooth_accelerations: true

--- a/crs_application/include/crs_application/common/config.h
+++ b/crs_application/include/crs_application/common/config.h
@@ -63,7 +63,6 @@ struct MotionPlanningConfig
 
   // media change
   double media_change_time;            /** @brief time that needs to elapse for the next media change secs */
-  Eigen::Isometry3d media_change_pose; /** @brief in world coordinates */
   std::vector<std::string> media_joint_names;
   std::vector<double> joint_media_position;
 

--- a/crs_application/include/crs_application/common/config.h
+++ b/crs_application/include/crs_application/common/config.h
@@ -105,6 +105,7 @@ struct PartRegistrationConfig
   std::string toolpath_file;
   std::array<double, 6> seed_pose;
   std::array<double, 6> simulation_pose;
+  double waypoint_edge_buffer;
 };
 
 struct PartReworkConfig

--- a/crs_application/include/crs_application/common/config.h
+++ b/crs_application/include/crs_application/common/config.h
@@ -62,7 +62,7 @@ struct MotionPlanningConfig
   double target_force = 20;
 
   // media change
-  double media_change_time;            /** @brief time that needs to elapse for the next media change secs */
+  double media_change_time; /** @brief time that needs to elapse for the next media change secs */
   std::vector<std::string> media_joint_names;
   std::vector<double> joint_media_position;
 

--- a/crs_application/resources/crs.rviz
+++ b/crs_application/resources/crs.rviz
@@ -11,8 +11,9 @@ Panels:
         - /Rework Detected Regions1/Namespaces1
         - /Rework Cropped Toolpaths1/Namespaces1
         - /Selectable Regions1
+        - /MarkerArray2
       Splitter Ratio: 0.44999998807907104
-    Tree Height: 922
+    Tree Height: 802
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -94,10 +95,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        preview/external_walls:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         preview/forearm_link:
           Alpha: 1
           Show Axes: false
@@ -107,6 +104,11 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        preview/robot_stand:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         preview/sander_center_link:
           Alpha: 1
           Show Axes: false
@@ -141,16 +143,6 @@ Visualization Manager:
           Show Trail: false
           Value: true
         preview/wrist_3_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        robot_stand:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        table:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -313,10 +305,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        external_walls:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         forearm_link:
           Alpha: 1
           Show Axes: false
@@ -341,11 +329,6 @@ Visualization Manager:
           Show Trail: false
           Value: true
         shoulder_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        table:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -465,7 +448,7 @@ Visualization Manager:
       Enabled: true
       Name: Process Planning Debug 3
       Namespaces:
-        "": true
+        {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -489,7 +472,7 @@ Visualization Manager:
       Enabled: true
       Name: Process Planning Debug 2
       Namespaces:
-        "": true
+        {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -508,9 +491,7 @@ Visualization Manager:
       Enabled: true
       Name: Rework Detected Regions
       Namespaces:
-        closed_regions1: true
-        closed_regions2: true
-        closed_regions3: true
+        {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -522,7 +503,7 @@ Visualization Manager:
       Enabled: true
       Name: Rework Cropped Toolpaths
       Namespaces:
-        toolpath: true
+        {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -545,6 +526,18 @@ Visualization Manager:
       Name: Axes
       Radius: 0.10000000149011612
       Reference Frame: world
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /crs/original_raster_paths
       Value: true
   Enabled: true
   Global Options:
@@ -589,41 +582,41 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 2.2505269050598145
+      Distance: 3.3550431728363037
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.00877167098224163
-        Y: -0.7050719261169434
-        Z: -0.5375691056251526
+        X: -0.9376643896102905
+        Y: 0.14379344880580902
+        Z: 1.135255217552185
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.4854006767272949
+      Pitch: 0.3054007887840271
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 5.828568458557129
+      Yaw: 3.4435672760009766
     Saved: ~
 Window Geometry:
   ApplicationPanel:
     collapsed: false
   Displays:
     collapsed: false
-  Height: 1172
+  Height: 1052
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd0000000400000000000002970000043afc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fc0000003d0000043a000002a00100001cfa000000010100000002fb000000100044006900730070006c0061007900730100000000ffffffff0000015600fffffffb00000020004100700070006c00690063006100740069006f006e00500061006e0065006c010000000000000297000001eb00ffffff000000010000010f000003a7fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000003a7000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000003a30000043a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd000000040000000000000297000003c2fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fc0000003d000003c2000002a00100001cfa000000010100000002fb000000100044006900730070006c0061007900730100000000ffffffff0000015600fffffffb00000020004100700070006c00690063006100740069006f006e00500061006e0065006c010000000000000297000001eb00ffffff000000010000010f000003a7fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000003a7000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000004e3000003c200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Tool Properties:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1600
-  X: 1920
+  Width: 1920
+  X: 3000
   Y: 0

--- a/crs_application/src/common/config.cpp
+++ b/crs_application/src/common/config.cpp
@@ -227,6 +227,7 @@ boost::optional<ProcessExecutionConfig> parse(YAML::Node& config, std::string& e
   using namespace config_fields::process_execution;
   ProcessExecutionConfig cfg;
 
+  // required parameters
   try
   {
     Node root_node = config[TOP_LEVEL];
@@ -268,6 +269,9 @@ boost::optional<ProcessExecutionConfig> parse(YAML::Node& config, std::string& e
     }
     else
     {
+      err_msg = boost::str(boost::format("Failed to find required fields  in %s yaml, using defaults") %
+                           typeid(ProcessExecutionConfig).name());
+      RCLCPP_ERROR(CONFIG_LOGGER, "%s", err_msg.c_str());
       return boost::none;
     }
   }
@@ -292,6 +296,7 @@ boost::optional<ProcessExecutionConfig> parse(YAML::Node& config, std::string& e
     RCLCPP_ERROR(CONFIG_LOGGER, "%s", err_msg.c_str());
     return boost::none;
   }
+
   return cfg;
 }
 
@@ -369,6 +374,8 @@ boost::optional<PartRegistrationConfig> parse(YAML::Node& config, std::string& e
   using namespace YAML;
   using namespace config_fields::part_registration;
   PartRegistrationConfig cfg;
+
+  // required parameters;
   try
   {
     Node root_node = config[TOP_LEVEL];
@@ -379,14 +386,11 @@ boost::optional<PartRegistrationConfig> parse(YAML::Node& config, std::string& e
       return boost::none;
     }
 
-    if (hasFields(root_node,
-                  TOP_LEVEL,
-                  { SIMULATION_POSE, SEED_POSE, TARGET_FRAME_ID, PART_FILE, TOOLPATH_FILE, TOOLPATH_EDGE_BUFFER }))
+    if (hasFields(root_node, TOP_LEVEL, { SIMULATION_POSE, SEED_POSE, TARGET_FRAME_ID, PART_FILE, TOOLPATH_FILE }))
     {
       cfg.target_frame_id = root_node[TARGET_FRAME_ID].as<std::string>();
       cfg.part_file = root_node[PART_FILE].as<std::string>();
       cfg.toolpath_file = root_node[TOOLPATH_FILE].as<std::string>();
-      cfg.waypoint_edge_buffer = root_node[TOOLPATH_EDGE_BUFFER].as<double>();
 
       // seed pose
       std::vector<double> pose_vals = root_node[SEED_POSE].as<std::vector<double>>();
@@ -421,6 +425,30 @@ boost::optional<PartRegistrationConfig> parse(YAML::Node& config, std::string& e
                          typeid(PartRegistrationConfig).name() % e.what());
     RCLCPP_ERROR(CONFIG_LOGGER, "%s", err_msg.c_str());
     return boost::none;
+  }
+
+  // optional parameters
+  try
+  {
+    Node root_node = config[TOP_LEVEL];
+    cfg.waypoint_edge_buffer = 0.0;
+
+    if (hasFields(root_node, TOP_LEVEL, { TOOLPATH_EDGE_BUFFER }))
+    {
+      cfg.waypoint_edge_buffer = root_node[TOOLPATH_EDGE_BUFFER].as<double>();
+    }
+    else
+    {
+      err_msg = boost::str(boost::format("Failed to find optional fields  in %s yaml, using defaults") %
+                           typeid(PartRegistrationConfig).name());
+      RCLCPP_WARN(CONFIG_LOGGER, "%s", err_msg.c_str());
+    }
+  }
+  catch (std::exception& e)
+  {
+    err_msg = boost::str(boost::format("Failed to parse optional fields  in %s yaml, using defaults") %
+                         typeid(PartRegistrationConfig).name());
+    RCLCPP_WARN(CONFIG_LOGGER, "%s", err_msg.c_str());
   }
   return cfg;
 }

--- a/crs_application/src/common/config.cpp
+++ b/crs_application/src/common/config.cpp
@@ -93,6 +93,7 @@ static const std::string SEED_POSE = "seed_pose";
 static const std::string TARGET_FRAME_ID = "target_frame_id";
 static const std::string PART_FILE = "part_file";
 static const std::string TOOLPATH_FILE = "toolpath_file";
+static const std::string TOOLPATH_EDGE_BUFFER = "toolpath_edge_buffer";
 }  // namespace part_registration
 
 namespace part_rework
@@ -386,11 +387,14 @@ boost::optional<PartRegistrationConfig> parse(YAML::Node& config, std::string& e
       return boost::none;
     }
 
-    if (hasFields(root_node, TOP_LEVEL, { SIMULATION_POSE, SEED_POSE, TARGET_FRAME_ID, PART_FILE, TOOLPATH_FILE }))
+    if (hasFields(root_node,
+                  TOP_LEVEL,
+                  { SIMULATION_POSE, SEED_POSE, TARGET_FRAME_ID, PART_FILE, TOOLPATH_FILE, TOOLPATH_EDGE_BUFFER }))
     {
       cfg.target_frame_id = root_node[TARGET_FRAME_ID].as<std::string>();
       cfg.part_file = root_node[PART_FILE].as<std::string>();
       cfg.toolpath_file = root_node[TOOLPATH_FILE].as<std::string>();
+      cfg.waypoint_edge_buffer = root_node[TOOLPATH_EDGE_BUFFER].as<double>();
 
       // seed pose
       std::vector<double> pose_vals = root_node[SEED_POSE].as<std::vector<double>>();

--- a/crs_application/src/common/config.cpp
+++ b/crs_application/src/common/config.cpp
@@ -56,9 +56,7 @@ static const std::string PREVIEW_ROOT = "preview";
 static const std::vector<std::string> HOME_POS_ITEMS = { "joint_names", "joint_position" };
 static const std::vector<std::string> PROCESS_PATH_ITEMS = { "tool_speed",    "offset_pose", "retreat_dist",
                                                              "approach_dist", "tool_frame",  "target_force" };
-static const std::vector<std::string> MEDIA_CHANGE_ITEMS = { "change_time",
-                                                             "joint_names",
-                                                             "joint_position" };
+static const std::vector<std::string> MEDIA_CHANGE_ITEMS = { "change_time", "joint_names", "joint_position" };
 static const std::vector<std::string> PREVIEW_ITEMS = { "time_scaling" };
 }  // namespace motion_planning
 

--- a/crs_application/src/common/config.cpp
+++ b/crs_application/src/common/config.cpp
@@ -57,7 +57,6 @@ static const std::vector<std::string> HOME_POS_ITEMS = { "joint_names", "joint_p
 static const std::vector<std::string> PROCESS_PATH_ITEMS = { "tool_speed",    "offset_pose", "retreat_dist",
                                                              "approach_dist", "tool_frame",  "target_force" };
 static const std::vector<std::string> MEDIA_CHANGE_ITEMS = { "change_time",
-                                                             "change_pose",
                                                              "joint_names",
                                                              "joint_position" };
 static const std::vector<std::string> PREVIEW_ITEMS = { "time_scaling" };
@@ -181,13 +180,8 @@ boost::optional<MotionPlanningConfig> parse(YAML::Node& config, std::string& err
     if (media_change_node && hasFields(media_change_node, MEDIA_CHANGE_ROOT, MEDIA_CHANGE_ITEMS))
     {
       cfg.media_change_time = media_change_node[MEDIA_CHANGE_ITEMS[0]].as<double>();
-      std::vector<double> xyzrpy = media_change_node[MEDIA_CHANGE_ITEMS[1]].as<std::vector<double>>();
-      cfg.media_change_pose = Eigen::Translation3d(Eigen::Vector3d(xyzrpy[0], xyzrpy[1], xyzrpy[2])) *
-                              Eigen::AngleAxisd(xyzrpy[3], Eigen::Vector3d::UnitX()) *
-                              Eigen::AngleAxisd(xyzrpy[4], Eigen::Vector3d::UnitY()) *
-                              Eigen::AngleAxisd(xyzrpy[5], Eigen::Vector3d::UnitZ());
-      cfg.media_joint_names = media_change_node[MEDIA_CHANGE_ITEMS[2]].as<std::vector<std::string>>();
-      cfg.joint_media_position = media_change_node[MEDIA_CHANGE_ITEMS[3]].as<std::vector<double>>();
+      cfg.media_joint_names = media_change_node[MEDIA_CHANGE_ITEMS[1]].as<std::vector<std::string>>();
+      cfg.joint_media_position = media_change_node[MEDIA_CHANGE_ITEMS[2]].as<std::vector<double>>();
     }
     else
     {

--- a/crs_application/src/task_managers/motion_planning_manager.cpp
+++ b/crs_application/src/task_managers/motion_planning_manager.cpp
@@ -395,19 +395,8 @@ common::ActionResult MotionPlanningManager::planMediaChanges()
 
   CallFreespaceMotion::Request::SharedPtr req = std::make_shared<CallFreespaceMotion::Request>();
   req->target_link = config_->tool_frame;
-  if (config_->joint_media_position.empty() || config_->media_joint_names.empty())
-  {
-    // use cartesian tool pose when no joint pose is available
-    geometry_msgs::msg::Pose pose_msg = tf2::toMsg(config_->media_change_pose);
-    std::tie(req->goal_pose.translation.x, req->goal_pose.translation.y, req->goal_pose.translation.z) =
-        std::make_tuple(pose_msg.position.x, pose_msg.position.y, pose_msg.position.z);
-    req->goal_pose.rotation = pose_msg.orientation;
-  }
-  else
-  {
-    req->goal_position.position = config_->joint_media_position;
-    req->goal_position.name = config_->media_joint_names;
-  }
+  req->goal_position.position = config_->joint_media_position;
+  req->goal_position.name = config_->media_joint_names;
   req->execute = false;
   req->num_steps = 0;  // planner should use default
 

--- a/crs_application/src/task_managers/part_registration_manager.cpp
+++ b/crs_application/src/task_managers/part_registration_manager.cpp
@@ -264,8 +264,9 @@ common::ActionResult PartRegistrationManager::computeTransform()
 
 common::ActionResult PartRegistrationManager::applyTransform()
 {
-  std::vector<geometry_msgs::msg::PoseArray> raster_strips;
-  crs_motion_planning::parsePathFromFile(config_->toolpath_file, config_->target_frame_id, raster_strips);
+  std::vector<geometry_msgs::msg::PoseArray> raster_strips1, raster_strips;
+  crs_motion_planning::parsePathFromFile(config_->toolpath_file, config_->target_frame_id, raster_strips1);
+  raster_strips = crs_motion_planning::removeEdgeWaypoints(raster_strips1, config_->waypoint_edge_buffer);
 
   auto apply_transform = [](const geometry_msgs::msg::Pose& p,
                             const geometry_msgs::msg::Transform& t) -> geometry_msgs::msg::Pose {

--- a/crs_motion_planning/include/crs_motion_planning/path_planning_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_planning_utils.h
@@ -159,6 +159,7 @@ struct pathPlanningConfig
   double max_joint_acc = 0.5;  // rad/s^2
 
   size_t minimum_raster_length = 2;
+  double reachable_radius = 1.0;
 
   bool trajopt_verbose_output = false;
 

--- a/crs_motion_planning/include/crs_motion_planning/path_planning_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_planning_utils.h
@@ -47,6 +47,8 @@ struct descartesConfig
   bool allow_collisions = false;
 
   Eigen::Isometry3d tool_offset = Eigen::Isometry3d::Identity();
+
+  std::vector<double> joint_min_vals;
 };
 
 struct trajoptSurfaceConfig
@@ -91,6 +93,10 @@ struct omplConfig
 
   double longest_valid_segment_fraction = 0.01;
   double longest_valid_segment_length = 0.5;
+
+  bool retry_failure = true;
+  double retry_distance = 0.002;
+  bool retry_at_zero = false;
 };
 
 struct trajoptFreespaceConfig
@@ -156,7 +162,8 @@ struct pathPlanningConfig
   double max_joint_vel = 0.2;  // rad/s
   double max_joint_vel_mult = 1.0;
   double max_surface_dist = 0.1;
-  double max_joint_acc = 0.5;  // rad/s^2
+  double max_rotation_rate = 3.0;  // rad/m
+  double max_joint_acc = 0.5;      // rad/s^2
 
   size_t minimum_raster_length = 2;
   double reachable_radius = 1.0;

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -151,6 +151,7 @@ bool splitRastersByJointDist(const trajectory_msgs::msg::JointTrajectory& given_
                              std::vector<trajectory_msgs::msg::JointTrajectory>& split_traj,
                              std::vector<geometry_msgs::msg::PoseArray>& split_rasters,
                              std::vector<std::vector<double>>& time_steps,
+                             const double& max_rotation_rate = 3.0,
                              const double& joint_vel_mult = 1.0);
 
 void addApproachAndRetreat(const geometry_msgs::msg::PoseArray& given_raster,
@@ -225,6 +226,19 @@ bool execSurfaceTrajectory(
     const cartesian_trajectory_msgs::msg::CartesianTrajectory& traj,
     const cartesianTrajectoryConfig& traj_config);
 
+///
+/// \brief removeEdgeWaypoints remove buffer from either side of the waypoints
+/// \return cropped waypoints
+///
+geometry_msgs::msg::PoseArray removeEdgeWaypoints(const geometry_msgs::msg::PoseArray& input_waypoints,
+                                                  const double& buffer);
+
+///
+/// \brief removeEdgeWaypoints remove buffer from either side of the waypoints
+/// \return cropped waypoints
+///
+std::vector<geometry_msgs::msg::PoseArray>
+removeEdgeWaypoints(const std::vector<geometry_msgs::msg::PoseArray>& input_waypoints, const double& buffer);
 
 ///
 /// \brief transformWaypoints Transform waypoints given transform
@@ -238,9 +252,10 @@ geometry_msgs::msg::PoseArray transformWaypoints(const geometry_msgs::msg::PoseA
 /// \brief transformWaypoints Transform waypoints given transform
 /// \return transformed waypoints
 ///
-std::vector<geometry_msgs::msg::PoseArray> transformWaypoints(const std::vector<geometry_msgs::msg::PoseArray>& input_waypoints,
-                                                              const geometry_msgs::msg::TransformStamped& transform,
-                                                              const bool inverse = false);
+std::vector<geometry_msgs::msg::PoseArray>
+transformWaypoints(const std::vector<geometry_msgs::msg::PoseArray>& input_waypoints,
+                   const geometry_msgs::msg::TransformStamped& transform,
+                   const bool inverse = false);
 
 ///
 /// \brief filterReachabilitySphere Removes any points outside of sphere of reachability from robot base
@@ -259,10 +274,29 @@ bool filterReachabilitySphere(const std::vector<geometry_msgs::msg::PoseArray>& 
                               std::vector<geometry_msgs::msg::PoseArray>& reachable_waypoints_vec);
 
 ///
-/// \brief organizeRasters Puts rasters in alternating order
-/// \return success
+/// \brief calcPoseDist calculates distance between two geometry_msgs Pose msgs
+/// \return distance between poses
 ///
-std::vector<geometry_msgs::msg::PoseArray> organizeRasters(const std::vector<geometry_msgs::msg::PoseArray>& waypoints_vec);
+double calcPoseDist(const geometry_msgs::msg::Pose& waypoint1, const geometry_msgs::msg::Pose& waypoint2);
+
+///
+/// \brief calcRotation calculates rotation between two geometry_msgs Pose msgs
+/// \return rotation between poses
+///
+double calcRotation(const geometry_msgs::msg::Pose& waypoint1, const geometry_msgs::msg::Pose& waypoint2);
+
+///
+/// \brief organizeRasters Puts rasters in alternating order
+/// \return organized waypoints
+///
+std::vector<geometry_msgs::msg::PoseArray>
+organizeRasters(const std::vector<geometry_msgs::msg::PoseArray>& waypoints_vec);
+
+///
+/// \brief findRasterRotation finds the rotation rate of a raster
+/// \return [max rotation in radians/m, avg rotation in radians/m]
+///
+std::vector<double> findRasterRotation(const geometry_msgs::msg::PoseArray& waypoints);
 
 }  // namespace crs_motion_planning
 

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -225,6 +225,45 @@ bool execSurfaceTrajectory(
     const cartesian_trajectory_msgs::msg::CartesianTrajectory& traj,
     const cartesianTrajectoryConfig& traj_config);
 
+
+///
+/// \brief transformWaypoints Transform waypoints given transform
+/// \return transformed waypoints
+///
+geometry_msgs::msg::PoseArray transformWaypoints(const geometry_msgs::msg::PoseArray& input_waypoints,
+                                                 const geometry_msgs::msg::TransformStamped& transform,
+                                                 const bool inverse = false);
+
+///
+/// \brief transformWaypoints Transform waypoints given transform
+/// \return transformed waypoints
+///
+std::vector<geometry_msgs::msg::PoseArray> transformWaypoints(const std::vector<geometry_msgs::msg::PoseArray>& input_waypoints,
+                                                              const geometry_msgs::msg::TransformStamped& transform,
+                                                              const bool inverse = false);
+
+///
+/// \brief filterReachabilitySphere Removes any points outside of sphere of reachability from robot base
+/// \return success
+///
+bool filterReachabilitySphere(const geometry_msgs::msg::PoseArray& waypoints,
+                              const double& radius,
+                              geometry_msgs::msg::PoseArray& reachable_waypoints);
+
+///
+/// \brief filterReachabilitySphere Removes any points outside of sphere of reachability from robot base
+/// \return success
+///
+bool filterReachabilitySphere(const std::vector<geometry_msgs::msg::PoseArray>& waypoints_vec,
+                              const double& radius,
+                              std::vector<geometry_msgs::msg::PoseArray>& reachable_waypoints_vec);
+
+///
+/// \brief organizeRasters Puts rasters in alternating order
+/// \return success
+///
+std::vector<geometry_msgs::msg::PoseArray> organizeRasters(const std::vector<geometry_msgs::msg::PoseArray>& waypoints_vec);
+
 }  // namespace crs_motion_planning
 
 #endif  // CRS_MOTION_PLANNING_PATH_PROCESSING_UTILS_H

--- a/crs_motion_planning/src/motion_planning_server.cpp
+++ b/crs_motion_planning/src/motion_planning_server.cpp
@@ -64,9 +64,10 @@ static const std::string NUM_FREEPSACE_STEPS = "num_steps";
 class MotionPlanningServer : public rclcpp::Node
 {
 public:
-  MotionPlanningServer(rclcpp::NodeOptions options) : Node("motion_planning_server_node", options)
-  , tf_buffer_(std::make_shared<rclcpp::Clock>(RCL_ROS_TIME))
-  , tf_listener_(tf_buffer_)
+  MotionPlanningServer(rclcpp::NodeOptions options)
+    : Node("motion_planning_server_node", options)
+    , tf_buffer_(std::make_shared<rclcpp::Clock>(RCL_ROS_TIME))
+    , tf_listener_(tf_buffer_)
   {
     namespace fs = boost::filesystem;
 
@@ -201,26 +202,33 @@ private:
       geometry_msgs::msg::TransformStamped transform;
       try
       {
-        transform = tf_buffer_.lookupTransform(
-            request->process_paths[i].rasters[0].header.frame_id, motion_planner_config->robot_base_frame, tf2::TimePointZero, tf2::Duration(5));
+        transform = tf_buffer_.lookupTransform(request->process_paths[i].rasters[0].header.frame_id,
+                                               motion_planner_config->robot_base_frame,
+                                               tf2::TimePointZero,
+                                               tf2::Duration(5));
       }
       catch (tf2::TransformException ex)
       {
-        std::string error_msg = "Failed to get transform from '" + request->process_paths[i].rasters[0].header.frame_id + "' to '" +
+        std::string error_msg = "Failed to get transform from '" +
+                                request->process_paths[i].rasters[0].header.frame_id + "' to '" +
                                 motion_planner_config->robot_base_frame + "' frame";
 
         RCLCPP_ERROR(this->get_logger(), "Raster Frame error: %s: ", ex.what(), error_msg.c_str());
         return;
       }
 
-      std::vector<geometry_msgs::msg::PoseArray> transformed_waypoints = crs_motion_planning::transformWaypoints(request->process_paths[i].rasters, transform);
+      std::vector<geometry_msgs::msg::PoseArray> organized_rasters =
+          crs_motion_planning::organizeRasters(request->process_paths[i].rasters);
+      std::vector<geometry_msgs::msg::PoseArray> transformed_waypoints =
+          crs_motion_planning::transformWaypoints(organized_rasters, transform);
       std::vector<geometry_msgs::msg::PoseArray> reachable_transformed_waypoints;
-      crs_motion_planning::filterReachabilitySphere(transformed_waypoints, motion_planner_config->reachable_radius, reachable_transformed_waypoints);
-      std::vector<geometry_msgs::msg::PoseArray> reachable_waypoints = crs_motion_planning::transformWaypoints(reachable_transformed_waypoints, transform, true);
+      crs_motion_planning::filterReachabilitySphere(
+          transformed_waypoints, motion_planner_config->reachable_radius, reachable_transformed_waypoints);
+      std::vector<geometry_msgs::msg::PoseArray> reachable_waypoints =
+          crs_motion_planning::transformWaypoints(reachable_transformed_waypoints, transform, true);
 
       // Load in current rasters
       motion_planner_config->rasters.clear();
-//      motion_planner_config->rasters = request->process_paths[i].rasters;
       motion_planner_config->rasters = reachable_waypoints;
 
       // Create marker array for original raster visualization

--- a/crs_motion_planning/src/path_planning_utils.cpp
+++ b/crs_motion_planning/src/path_planning_utils.cpp
@@ -2,7 +2,6 @@
 #include <tesseract_rosutils/conversions.h>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("PATH_PLANNING_UTILS");
-static const double MINIMUM_WRIST_2_ABS_VAL = 0.1;
 
 namespace crs_motion_planning
 {
@@ -32,6 +31,7 @@ bool loadPathPlanningConfig(const std::string& yaml_fp, pathPlanningConfig& moti
                                    Eigen::AngleAxisd(xyzrpy[4], Eigen::Vector3d::UnitY()) *
                                    Eigen::AngleAxisd(xyzrpy[5], Eigen::Vector3d::UnitZ());
     descartes_config.allow_collisions = false;
+    descartes_config.joint_min_vals = descartes_yaml["joint_min_vals"].as<std::vector<double>>();
 
     // TRAJOPT SURFACE CONFIG
     YAML::Node trajopt_surface_yaml = full_yaml_node["trajopt_surface"];
@@ -100,6 +100,9 @@ bool loadPathPlanningConfig(const std::string& yaml_fp, pathPlanningConfig& moti
     ompl_config.n_output_states = ompl_yaml["default_n_output_states"].as<double>();
     ompl_config.longest_valid_segment_fraction = ompl_yaml["longest_valid_segment_fraction"].as<double>();
     ompl_config.longest_valid_segment_length = ompl_yaml["longest_valid_segment_length"].as<double>();
+    ompl_config.retry_failure = ompl_yaml["retry_failure"].as<bool>();
+    ompl_config.retry_distance = ompl_yaml["retry_distance"].as<double>();
+    ompl_config.retry_at_zero = ompl_yaml["retry_at_zero"].as<bool>();
 
     // TRAJOPT FREESPACE CONFIG
     YAML::Node trajopt_freespace_yaml = full_yaml_node["trajopt_freespace"];
@@ -165,6 +168,7 @@ bool loadPathPlanningConfig(const std::string& yaml_fp, pathPlanningConfig& moti
     motion_planner_config.max_joint_vel = general_yaml["max_joint_vel"].as<double>();
     motion_planner_config.max_joint_vel_mult = general_yaml["max_joint_vel_mult"].as<double>();
     motion_planner_config.max_surface_dist = general_yaml["max_surface_dist"].as<double>();
+    motion_planner_config.max_rotation_rate = general_yaml["max_rotation_rate"].as<double>();
     motion_planner_config.max_joint_acc = general_yaml["max_joint_acc"].as<double>();
     motion_planner_config.add_approach_and_retreat = general_yaml["add_approach_and_retreat"].as<bool>();
     motion_planner_config.minimum_raster_length = general_yaml["minimum_raster_length"].as<std::size_t>();
@@ -239,8 +243,13 @@ bool crsMotionPlanner::generateDescartesSeed(const geometry_msgs::msg::PoseArray
 
   // Function to make sure wrist 2 isn't close to zero to avoid wrist singularities
   std::function<bool(const double*)> isValidFn = [&](const double* joints) {
-    if (abs(joints[4]) < MINIMUM_WRIST_2_ABS_VAL)
-      return false;
+    for (size_t i = 0; i < config_->descartes_config.joint_min_vals.size(); ++i)
+    {
+      if (abs(joints[i]) < config_->descartes_config.joint_min_vals[i])
+      {
+        return false;
+      }
+    }
     return true;
   };
 
@@ -458,6 +467,7 @@ bool crsMotionPlanner::generateSurfacePlans(pathPlanningResults::Ptr& results)
                                                        double_split_traj,
                                                        resplit_rasters,
                                                        time_steps,
+                                                       config_->max_rotation_rate,
                                                        config_->max_joint_vel_mult))
       {
         RCLCPP_INFO(logger_, "FOUND A SPLIT");
@@ -829,7 +839,36 @@ bool crsMotionPlanner::generateOMPLSeed(const tesseract_motion_planners::JointWa
 
   if (!ompl_planner.setConfiguration(ompl_planner_config))
   {
-    return false;
+    if (config_->ompl_config.retry_failure)
+    {
+      RCLCPP_WARN(logger_,
+                  "Failed to set configuration for OMPL, retrying with %f collision distance",
+                  config_->ompl_config.retry_distance);
+      ompl_planner_config->collision_safety_margin = config_->ompl_config.retry_distance;
+      if (!ompl_planner.setConfiguration(ompl_planner_config))
+      {
+        if (config_->ompl_config.retry_at_zero)
+        {
+          RCLCPP_WARN(logger_, "Failed to set configuration for OMPL, retrying with 0 collision distance");
+          ompl_planner_config->collision_safety_margin = 0;
+          if (!ompl_planner.setConfiguration(ompl_planner_config))
+          {
+            RCLCPP_ERROR(logger_, "Failed to set configuration for OMPL again");
+            return false;
+          }
+        }
+        else
+        {
+          RCLCPP_ERROR(logger_, "Failed to set configuration for OMPL again");
+          return false;
+        }
+      }
+    }
+    else
+    {
+      RCLCPP_ERROR(logger_, "Failed to set configuration for OMPL again");
+      return false;
+    }
   }
   RCLCPP_INFO(logger_, "OMPL CONFIGURATION SET");
 

--- a/crs_motion_planning/src/path_planning_utils.cpp
+++ b/crs_motion_planning/src/path_planning_utils.cpp
@@ -168,6 +168,7 @@ bool loadPathPlanningConfig(const std::string& yaml_fp, pathPlanningConfig& moti
     motion_planner_config.max_joint_acc = general_yaml["max_joint_acc"].as<double>();
     motion_planner_config.add_approach_and_retreat = general_yaml["add_approach_and_retreat"].as<bool>();
     motion_planner_config.minimum_raster_length = general_yaml["minimum_raster_length"].as<std::size_t>();
+    motion_planner_config.reachable_radius = general_yaml["reachable_radius"].as<double>();
     motion_planner_config.trajopt_verbose_output = general_yaml["trajopt_verbose_output"].as<bool>();
     motion_planner_config.combine_strips = general_yaml["combine_strips"].as<bool>();
     motion_planner_config.global_descartes = general_yaml["global_descartes"].as<bool>();

--- a/crs_process_data/data/main/toolpaths/part_2/configs/job_0_degrees_20200520T192241.997282_config.yaml
+++ b/crs_process_data/data/main/toolpaths/part_2/configs/job_0_degrees_20200520T192241.997282_config.yaml
@@ -11,6 +11,7 @@ crs:
       retreat_dist: 0.03
       approach_dist: 0.03
       tool_frame: sander_center_link
+      target_force: 20
     media_change:
       change_time: 300.0
       change_pose: [-0.381, -0.202, 1.5, 0.0, -0.786, 1.57]

--- a/crs_process_data/data/main/toolpaths/part_5/crs.yaml
+++ b/crs_process_data/data/main/toolpaths/part_5/crs.yaml
@@ -4,56 +4,51 @@ crs:
     pre_move_home: false
     home_position:
       joint_names: [shoulder_pan_joint, shoulder_lift_joint, elbow_joint, wrist_1_joint, wrist_2_joint, wrist_3_joint]
-      joint_position: [-0.9644, -1.3617, 2.0724, -0.7108, -0.9640, 0.7994]
+      joint_position: [-1.8444, -1.85261, -1.6167, -1.6665, 0.8773, -0.9489]
     process_path:
-      tool_speed: 0.1
+      tool_speed: 0.05
       offset_pose: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-      retreat_dist: 0.03
-      approach_dist: 0.03
+      retreat_dist: 0.025
+      approach_dist: 0.025
       tool_frame: sander_center_link
       target_force: 15
     media_change:
-      change_time: 300.0
-      change_pose: [-0.381, -0.202, 1.5, 0.0, -0.786, 1.57]
+      change_time: 1200.0
       joint_names: [shoulder_pan_joint, shoulder_lift_joint, elbow_joint, wrist_1_joint, wrist_2_joint, wrist_3_joint]
-      joint_position: []
+      joint_position: [-0.02467, -1.7719, -1.8680, -0.6212, 0.90265, -2.2430]
     preview:
       time_scaling: 4.0
   scan_acquisition:
     scan_poses:
-      - pose: [-1.444, -0.322, 1.495, 2.5029407, 0.9721462, -2.3962962]
-      - pose: [-0.869, -0.397, 1.559, -3.1289652, 0.6427091, 3.1099935]
-      - pose: [0.005, 0.621, 1.534, -2.6741055, -0.6119461, -1.9862345]
-      - pose: [-0.348, -0.211, 1.555, -2.2509677, -0.1362007, -3.0876068]
-      - pose: [0.036, 0.258, 1.549, -2.4653191, -0.7150566, 2.9155958]
-      - pose: [-0.201, -0.062, 1.604, 2.4117773, -0.3157807, -2.7579127]
-      - pose: [-0.045, 0.794, 1.580, 2.3330813, -0.3216955, -2.8142385]
+      - pose: [-1.483, -0.229, 1.735, 2.797, 1.17, -2.43]
+      - pose: [-1.527, -0.239, 1.731, 2.74, 0.66, -2.79]
+      - pose: [-1.698, 0.357, 1.445, 2.955, 0.904, -1.36]
     tool_frame: camera_link_optical
     skip_on_failure: true
   process_execution:
-    time_tolerance: 5.0
+    time_tolerance: 120.0
     joint_tolerance: [0.035, 0.035, 0.035, 0.035, 0.035, 0.035]
-    cartesian_path_tolerance: [0.015, 0.015, 0.025, 0.15, 0.15, 0.15]
-    cartesian_goal_tolerance: [0.01, 0.01, 0.01, 0.05, 0.05, 0.05]
-    force_tolerance: 10
-    force_controlled_trajectories: true
+    cartesian_path_tolerance: [0.015, 0.015, 0.035, 0.15, 0.15, 0.15]
+    cartesian_goal_tolerance: [0.01, 0.01, 0.025, 0.05, 0.05, 0.05]
+    force_tolerance: 5
+    force_controlled_trajectories: false
     ur_tool_change_script: simpleMove.urp
     execute_tool_change: false
   part_registration:
-    simulation_pose: [-0.22, 0.0, 1.0, 0.0, 0.0, 0.3]
-    seed_pose: [-0.22, 0.0, 0.96, 0.0, 0.0, 0.32]
+    simulation_pose: [-0.55, 0.0, 0.98, 0.0, 0.0, -2.8]
+    seed_pose: [-0.55, 0.0, 0.98, 0.0, 0.0, -2.8]
+    #seed_pose: [-0.75, 0.0, 1.1, 0.0, 0.0, -2.8]
     target_frame_id: world
     part_file: ""
     toolpath_file: ""
+    toolpath_edge_buffer: 0.15
   part_rework:
     scan_poses:
-      - pose: [-1.444, -0.322, 1.495, 2.5029407, 0.9721462, -2.3962962]
-      - pose: [-0.869, -0.397, 1.559, -3.1289652, 0.6427091, 3.1099935]
-      - pose: [0.005, 0.621, 1.534, -2.6741055, -0.6119461, -1.9862345]
-      - pose: [-0.348, -0.211, 1.555, -2.2509677, -0.1362007, -3.0876068]
-      - pose: [0.036, 0.258, 1.549, -2.4653191, -0.7150566, 2.9155958]
-      - pose: [-0.201, -0.062, 1.604, 2.4117773, -0.3157807, -2.7579127]
-      - pose: [-0.045, 0.794, 1.580, 2.3330813, -0.3216955, -2.8142385]
+      - pose: [0.0, -0.50, 1.7, 0.0, -2.35619, 1.57]
+      - pose: [0.0, -0.25, 1.7, 0.0, -2.35619, 1.57]
+      - pose: [0.0, -0.10, 1.7, 0.5, -2.35619, 1.57]
+      - pose: [0.0, 0.0, 1.7, 0.0, -2.35619, 1.57]
+      - pose: [0.0, 0.1, 1.7, -0.8, -2.35619, 1.57]
     tool_frame: camera_link_optical
     pre_acquisition_pause: 2.0
     skip_on_failure: true


### PR DESCRIPTION
Added several features with the aim of improving motion planning

- Ability to configurably add buffer to ends of raster strips (to avoid getting to close to the edge of the part)

- Ability to define a "sphere of reachability" from the base of the robot to prevent the robot from over extending

- Ability to define minimum absolute joint values for each joint when going through descartes (helps prevent singularities)

- Added new parameter to split toolpaths based on rotation rate between adjacent points (results on better individual rasters and gets rid of points on areas of sharp curvature)

- Added ability for OMPL to retry with smaller constraints if start or end state is thought to be in collision (prevents rare error that would cause OMPL to fail after trajopt smoothed a surface path)

- Added various helper functions to path_processing_tools

- Removed unnecessary media change_pose parameter that was no longer used
