### PR TITLE
Fix/check joints before freespace

### DIFF
--- a/crs_application/include/crs_application/task_managers/process_execution_manager.h
+++ b/crs_application/include/crs_application/task_managers/process_execution_manager.h
@@ -44,6 +44,7 @@
 #include <crs_motion_planning/path_processing_utils.h>
 #include <std_srvs/srv/set_bool.hpp>
 #include <crs_msgs/srv/run_robot_script.hpp>
+#include <crs_msgs/srv/call_freespace_motion.hpp>
 #include "crs_application/common/common.h"
 #include "crs_application/common/datatypes.h"
 #include "crs_application/common/config.h"
@@ -98,6 +99,8 @@ protected:
                                              const crs_motion_planning::cartesianTrajectoryConfig& traj_config);
   common::ActionResult checkPreReq();
 
+  void jointCallback(const sensor_msgs::msg::JointState::SharedPtr joint_msg);
+
   // roscpp
   using GoalHandleT = rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::GoalHandle;
   std::shared_ptr<rclcpp::Node> node_;
@@ -109,12 +112,15 @@ protected:
   rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr controller_changer_client_;
   rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr toggle_sander_client_;
   rclcpp::Client<crs_msgs::srv::RunRobotScript>::SharedPtr run_robot_script_client_;
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_listener_;
+  rclcpp::Client<crs_msgs::srv::CallFreespaceMotion>::SharedPtr call_freespace_client_;
 
   // process data
   std::shared_ptr<config::ProcessExecutionConfig> config_ = nullptr;
   std::shared_ptr<datatypes::ProcessExecutionData> input_ = nullptr;
 
   // other
+  sensor_msgs::msg::JointState curr_joint_state_;
   int current_process_idx_ = 0;
   int current_media_change_idx_ = 0;
   bool no_more_media_changes_ = false;

--- a/crs_application/include/crs_application/task_managers/process_execution_manager.h
+++ b/crs_application/include/crs_application/task_managers/process_execution_manager.h
@@ -112,7 +112,6 @@ protected:
   rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr controller_changer_client_;
   rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr toggle_sander_client_;
   rclcpp::Client<crs_msgs::srv::RunRobotScript>::SharedPtr run_robot_script_client_;
-  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_listener_;
   rclcpp::Client<crs_msgs::srv::CallFreespaceMotion>::SharedPtr call_freespace_client_;
 
   // process data
@@ -120,7 +119,6 @@ protected:
   std::shared_ptr<datatypes::ProcessExecutionData> input_ = nullptr;
 
   // other
-  sensor_msgs::msg::JointState curr_joint_state_;
   int current_process_idx_ = 0;
   int current_media_change_idx_ = 0;
   bool no_more_media_changes_ = false;

--- a/crs_application/src/task_managers/motion_planning_manager.cpp
+++ b/crs_application/src/task_managers/motion_planning_manager.cpp
@@ -334,13 +334,6 @@ common::ActionResult MotionPlanningManager::planProcessPaths()
       continue;
     }
 
-    if (plan.start.points.empty() || plan.end.points.empty())
-    {
-      RCLCPP_ERROR(node_->get_logger(), "Start or End move for process %i are empty, invalidating plan", i);
-      plan.process_motions.clear();
-      continue;
-    }
-
     found_valid_plan = true;
   }
   return found_valid_plan;
@@ -394,17 +387,16 @@ common::ActionResult MotionPlanningManager::planMediaChanges()
     return true;
   }
 
-  CallFreespaceMotion::Request::SharedPtr req = std::make_shared<CallFreespaceMotion::Request>();
-  req->target_link = config_->tool_frame;
-  req->goal_position.position = config_->joint_media_position;
-  req->goal_position.name = config_->media_joint_names;
-  req->execute = false;
-  req->num_steps = 0;  // planner should use default
-
   // Create media change plans
   std::vector<int> empty_process_indices;
   for (std::size_t i = 0; i < result_.process_plans.size() - 1; i++)
   {
+    CallFreespaceMotion::Request::SharedPtr req = std::make_shared<CallFreespaceMotion::Request>();
+    req->target_link = config_->tool_frame;
+    req->goal_position.position = config_->joint_media_position;
+    req->goal_position.name = config_->media_joint_names;
+    req->execute = false;
+    req->num_steps = 0;  // planner should use default
     datatypes::MediaChangeMotionPlan media_change_plan;
 
     // check if current motion plan is empty
@@ -422,7 +414,7 @@ common::ActionResult MotionPlanningManager::planMediaChanges()
     }
 
     // creating the media change plan now
-    const trajectory_msgs::msg::JointTrajectory& traj = result_.process_plans[i].end;
+    const trajectory_msgs::msg::JointTrajectory& traj = result_.process_plans[i].process_motions.back();
 
     // check trajectory
     if (traj.points.empty())

--- a/crs_application/src/task_managers/process_execution_manager.cpp
+++ b/crs_application/src/task_managers/process_execution_manager.cpp
@@ -451,7 +451,8 @@ common::ActionResult ProcessExecutionManager::execTrajectory(const trajectory_ms
     return res;
   }
 
-  // Check if joint state is in correct position before executing, if not then call a freespace motion from current joint state to beginning of trajectory
+  // Check if joint state is in correct position before executing, if not then call a freespace motion from current
+  // joint state to beginning of trajectory
   if (!crs_motion_planning::checkJointState(traj, curr_joint_state_, config_->joint_tolerance[0]))
   {
     RCLCPP_WARN(node_->get_logger(), "Not at the correct joint state to start freespace motion");
@@ -460,7 +461,8 @@ common::ActionResult ProcessExecutionManager::execTrajectory(const trajectory_ms
       RCLCPP_ERROR(node_->get_logger(), "%s Freespace Motion is not ready`", MANAGER_NAME.c_str());
       return false;
     }
-    crs_msgs::srv::CallFreespaceMotion::Request::SharedPtr freespace_req = std::make_shared<crs_msgs::srv::CallFreespaceMotion::Request>();
+    crs_msgs::srv::CallFreespaceMotion::Request::SharedPtr freespace_req =
+        std::make_shared<crs_msgs::srv::CallFreespaceMotion::Request>();
     freespace_req->goal_position.name = traj.joint_names;
     freespace_req->goal_position.position = traj.points.front().positions;
     freespace_req->start_position = curr_joint_state_;

--- a/crs_application/src/task_managers/process_execution_manager.cpp
+++ b/crs_application/src/task_managers/process_execution_manager.cpp
@@ -38,6 +38,7 @@
 
 static const double WAIT_SERVER_TIMEOUT = 10.0;  // seconds
 static const double WAIT_ROBOT_STOP = 2.0;
+static const double WAIT_MOTION_COMPLETION = 60.0;
 static const int WAIT_TOOL_CHANGE_COMPLETION = 600;  // seconds
 static const std::string MANAGER_NAME = "ProcessExecutionManager";
 static const std::string FOLLOW_JOINT_TRAJECTORY_ACTION = "follow_joint_trajectory";
@@ -45,6 +46,8 @@ static const std::string SURFACE_TRAJECTORY_ACTION = "execute_surface_motion";
 static const std::string CONTROLLER_CHANGER_SERVICE = "compliance_controller_on";
 static const std::string RUN_ROBOT_SCRIPT_SERVICE = "run_robot_script";
 static const std::string TOGGLE_SANDER_SERVICE = "toggle_sander";
+static const std::string JOINT_STATES_TOPIC = "joint_states";
+static const std::string FREESPACE_MOTION_PLANNING_SERVICE = "plan_freespace_motion";
 
 namespace crs_application
 {
@@ -74,6 +77,11 @@ ProcessExecutionManager::ProcessExecutionManager(std::shared_ptr<rclcpp::Node> n
   toggle_sander_client_ = node_->create_client<std_srvs::srv::SetBool>(TOGGLE_SANDER_SERVICE);
 
   run_robot_script_client_ = node_->create_client<crs_msgs::srv::RunRobotScript>(RUN_ROBOT_SCRIPT_SERVICE);
+
+  joint_state_listener_ = node_->create_subscription<sensor_msgs::msg::JointState>(
+      JOINT_STATES_TOPIC, 1, std::bind(&ProcessExecutionManager::jointCallback, this, std::placeholders::_1));
+
+  call_freespace_client_ = node_->create_client<crs_msgs::srv::CallFreespaceMotion>(FREESPACE_MOTION_PLANNING_SERVICE);
 }
 
 ProcessExecutionManager::~ProcessExecutionManager() {}
@@ -442,6 +450,39 @@ common::ActionResult ProcessExecutionManager::execTrajectory(const trajectory_ms
     res.succeeded = false;
     return res;
   }
+
+  // Check if joint state is in correct position before executing, if not then call a freespace motion from current joint state to beginning of trajectory
+  if (!crs_motion_planning::checkJointState(traj, curr_joint_state_, config_->joint_tolerance[0]))
+  {
+    RCLCPP_WARN(node_->get_logger(), "Not at the correct joint state to start freespace motion");
+    if (!call_freespace_client_->service_is_ready())
+    {
+      RCLCPP_ERROR(node_->get_logger(), "%s Freespace Motion is not ready`", MANAGER_NAME.c_str());
+      return false;
+    }
+    crs_msgs::srv::CallFreespaceMotion::Request::SharedPtr freespace_req = std::make_shared<crs_msgs::srv::CallFreespaceMotion::Request>();
+    freespace_req->goal_position.name = traj.joint_names;
+    freespace_req->goal_position.position = traj.points.front().positions;
+    freespace_req->start_position = curr_joint_state_;
+    freespace_req->execute = true;
+
+    auto result_future = call_freespace_client_->async_send_request(freespace_req);
+
+    std::future_status status = result_future.wait_for(std::chrono::duration<double>(WAIT_MOTION_COMPLETION));
+    if (status != std::future_status::ready)
+    {
+      RCLCPP_ERROR(node_->get_logger(), "%s Call Freespace Motion service call timedout", MANAGER_NAME.c_str());
+      return false;
+    }
+    auto result = result_future.get();
+
+    if (!result->success)
+    {
+      RCLCPP_ERROR(node_->get_logger(), "%s %s", MANAGER_NAME.c_str(), result->message.c_str());
+      return false;
+    }
+  }
+
   res.succeeded = crs_motion_planning::execTrajectory(trajectory_exec_client_, node_->get_logger(), traj);
   if (!res)
   {
@@ -466,7 +507,6 @@ ProcessExecutionManager::execSurfaceTrajectory(const cartesian_trajectory_msgs::
     res.succeeded = false;
     return res;
   }
-
   res.succeeded = crs_motion_planning::execSurfaceTrajectory(
       surface_trajectory_exec_client_, node_->get_logger(), traj, traj_config);
   if (!ProcessExecutionManager::toggleSander(false))
@@ -516,6 +556,11 @@ common::ActionResult ProcessExecutionManager::checkPreReq()
     return res;
   }
   return true;
+}
+
+void ProcessExecutionManager::jointCallback(const sensor_msgs::msg::JointState::SharedPtr joint_msg)
+{
+  curr_joint_state_ = *joint_msg;
 }
 
 } /* namespace task_managers */

--- a/crs_application/src/task_managers/process_execution_manager.cpp
+++ b/crs_application/src/task_managers/process_execution_manager.cpp
@@ -138,7 +138,7 @@ common::ActionResult ProcessExecutionManager::execProcess()
 
   RCLCPP_INFO(node_->get_logger(), "%s Executing process %i", MANAGER_NAME.c_str(), current_process_idx_);
 
-  if (!execTrajectory(process_plan.start))
+  if (process_plan.start.points.size() > 0 && !execTrajectory(process_plan.start))
   {
     common::ActionResult res;
     res.err_msg = boost::str(boost::format("%s failed to execute start motion") % MANAGER_NAME.c_str());
@@ -195,7 +195,7 @@ common::ActionResult ProcessExecutionManager::execProcess()
   }
 
   RCLCPP_INFO(node_->get_logger(), "%s Executing end motion", MANAGER_NAME.c_str());
-  if (!execTrajectory(process_plan.end))
+  if (process_plan.end.points.size() > 0 && !execTrajectory(process_plan.end))
   {
     common::ActionResult res;
     res.err_msg = boost::str(boost::format("%s failed to execute end motion") % MANAGER_NAME.c_str());

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -274,6 +274,20 @@ bool filterReachabilitySphere(const std::vector<geometry_msgs::msg::PoseArray>& 
                               std::vector<geometry_msgs::msg::PoseArray>& reachable_waypoints_vec);
 
 ///
+/// \brief filterSingularityCylinder Removes any points inside cylinder coming from UR base
+/// \return filtered points
+///
+geometry_msgs::msg::PoseArray filterSingularityCylinder(const geometry_msgs::msg::PoseArray& waypoints,
+                                                        const double& radius);
+
+///
+/// \brief filterSingularityCylinder Removes any points inside cylinder coming from UR base
+/// \return filtered points
+///
+std::vector<geometry_msgs::msg::PoseArray>
+filterSingularityCylinder(const std::vector<geometry_msgs::msg::PoseArray>& waypoints, const double& radius);
+
+///
 /// \brief calcPoseDist calculates distance between two geometry_msgs Pose msgs
 /// \return distance between poses
 ///

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -11,6 +11,7 @@
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2/transform_storage.h>
 #include <tf2/transform_datatypes.h>
@@ -311,6 +312,12 @@ organizeRasters(const std::vector<geometry_msgs::msg::PoseArray>& waypoints_vec)
 /// \return [max rotation in radians/m, avg rotation in radians/m]
 ///
 std::vector<double> findRasterRotation(const geometry_msgs::msg::PoseArray& waypoints);
+
+///
+/// \brief checkJointState checks if current joint state is expected starting joint state
+/// \return bool of yes or no
+///
+bool checkJointState(const trajectory_msgs::msg::JointTrajectory& traj, const sensor_msgs::msg::JointState joint_state, const double tolerance = 0.01);
 
 }  // namespace crs_motion_planning
 

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -317,7 +317,9 @@ std::vector<double> findRasterRotation(const geometry_msgs::msg::PoseArray& wayp
 /// \brief checkJointState checks if current joint state is expected starting joint state
 /// \return bool of yes or no
 ///
-bool checkJointState(const trajectory_msgs::msg::JointTrajectory& traj, const sensor_msgs::msg::JointState joint_state, const double tolerance = 0.01);
+bool checkJointState(const trajectory_msgs::msg::JointTrajectory& traj,
+                     const sensor_msgs::msg::JointState joint_state,
+                     const double tolerance = 0.01);
 
 }  // namespace crs_motion_planning
 

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -275,14 +275,14 @@ bool filterReachabilitySphere(const std::vector<geometry_msgs::msg::PoseArray>& 
                               std::vector<geometry_msgs::msg::PoseArray>& reachable_waypoints_vec);
 
 ///
-/// \brief filterSingularityCylinder Removes any points inside cylinder coming from UR base
+/// \brief filterSingularityCylinder Removes any points inside cylinder coming from robot base
 /// \return filtered points
 ///
 geometry_msgs::msg::PoseArray filterSingularityCylinder(const geometry_msgs::msg::PoseArray& waypoints,
                                                         const double& radius);
 
 ///
-/// \brief filterSingularityCylinder Removes any points inside cylinder coming from UR base
+/// \brief filterSingularityCylinder Removes any points inside cylinder coming from robot base
 /// \return filtered points
 ///
 std::vector<geometry_msgs::msg::PoseArray>
@@ -314,10 +314,10 @@ organizeRasters(const std::vector<geometry_msgs::msg::PoseArray>& waypoints_vec)
 std::vector<double> findRasterRotation(const geometry_msgs::msg::PoseArray& waypoints);
 
 ///
-/// \brief checkJointState checks if current joint state is expected starting joint state
+/// \brief checkStartState checks if current joint state is expected starting joint state
 /// \return bool of yes or no
 ///
-bool checkJointState(const trajectory_msgs::msg::JointTrajectory& traj,
+bool checkStartState(const trajectory_msgs::msg::JointTrajectory& traj,
                      const sensor_msgs::msg::JointState joint_state,
                      const double tolerance = 0.01);
 

--- a/crs_motion_planning/src/motion_planning_server.cpp
+++ b/crs_motion_planning/src/motion_planning_server.cpp
@@ -514,28 +514,33 @@ private:
                   std::shared_ptr<crs_msgs::srv::RobotPositioner::Response> response)
   {
     Eigen::Isometry3d ur_base_pose = Eigen::Isometry3d::Identity();
-    ur_base_pose.rotate(Eigen::Quaterniond(0.7071, 0, 0.7071, 0));
+//    ur_base_pose.rotate(Eigen::Quaterniond(0.7071, 0, 0.7071, 0));
+    ur_base_pose.rotate(Eigen::Quaterniond(0.5, -0.5, -0.5, -0.5));
     if (request->robot_rail == crs_msgs::srv::RobotPositioner::Request::RAIL1)
     {
       ur_base_pose.translation().x() = -0.148896;
     }
     else
     {
-      ur_base_pose.translation().x() = -1.050659;
+//      ur_base_pose.translation().x() = -1.050659;
+      ur_base_pose.translation().x() = -1.030659;
     }
     if (request->robot_position == crs_msgs::srv::RobotPositioner::Request::POSITION1)
     {
-      ur_base_pose.translation().z() = 0.6277;
+//      ur_base_pose.translation().z() = 0.6277;
+      ur_base_pose.translation().z() = 0.7977;
     }
     else if (request->robot_position == crs_msgs::srv::RobotPositioner::Request::POSITION2)
     {
-      ur_base_pose.translation().z() = -0.0277;
+//      ur_base_pose.translation().z() = -0.0277;
+      ur_base_pose.translation().z() = 0.1532;
     }
     else
     {
       ur_base_pose.translation().z() = -0.6677;
     }
-    ur_base_pose.translation().y() = -2.047406;
+//    ur_base_pose.translation().y() = -2.047406;
+    ur_base_pose.translation().y() = -2.037406;
 
     std::vector<tesseract_msgs::msg::EnvironmentCommand> env_command_vector;
     tesseract_msgs::msg::EnvironmentCommand move_ur_joint_command;

--- a/crs_motion_planning/src/motion_planning_server.cpp
+++ b/crs_motion_planning/src/motion_planning_server.cpp
@@ -514,7 +514,6 @@ private:
                   std::shared_ptr<crs_msgs::srv::RobotPositioner::Response> response)
   {
     Eigen::Isometry3d ur_base_pose = Eigen::Isometry3d::Identity();
-//    ur_base_pose.rotate(Eigen::Quaterniond(0.7071, 0, 0.7071, 0));
     ur_base_pose.rotate(Eigen::Quaterniond(0.5, -0.5, -0.5, -0.5));
     if (request->robot_rail == crs_msgs::srv::RobotPositioner::Request::RAIL1)
     {
@@ -522,24 +521,20 @@ private:
     }
     else
     {
-//      ur_base_pose.translation().x() = -1.050659;
       ur_base_pose.translation().x() = -1.030659;
     }
     if (request->robot_position == crs_msgs::srv::RobotPositioner::Request::POSITION1)
     {
-//      ur_base_pose.translation().z() = 0.6277;
       ur_base_pose.translation().z() = 0.7977;
     }
     else if (request->robot_position == crs_msgs::srv::RobotPositioner::Request::POSITION2)
     {
-//      ur_base_pose.translation().z() = -0.0277;
       ur_base_pose.translation().z() = 0.1532;
     }
     else
     {
       ur_base_pose.translation().z() = -0.6677;
     }
-//    ur_base_pose.translation().y() = -2.047406;
     ur_base_pose.translation().y() = -2.037406;
 
     std::vector<tesseract_msgs::msg::EnvironmentCommand> env_command_vector;

--- a/crs_motion_planning/src/path_processing_utils.cpp
+++ b/crs_motion_planning/src/path_processing_utils.cpp
@@ -1090,6 +1090,35 @@ bool crs_motion_planning::filterReachabilitySphere(const std::vector<geometry_ms
   return some_points_reachable;
 }
 
+geometry_msgs::msg::PoseArray
+crs_motion_planning::filterSingularityCylinder(const geometry_msgs::msg::PoseArray& waypoints, const double& radius)
+{
+  geometry_msgs::msg::PoseArray filtered_waypoints;
+  filtered_waypoints.header = waypoints.header;
+  for (auto pose : waypoints.poses)
+  {
+    double rad_point = sqrt(pow(pose.position.x,2) + pow(pose.position.y,2));
+    if (rad_point > radius)
+    {
+      filtered_waypoints.poses.push_back(pose);
+    }
+  }
+  return filtered_waypoints;
+}
+
+std::vector<geometry_msgs::msg::PoseArray>
+crs_motion_planning::filterSingularityCylinder(const std::vector<geometry_msgs::msg::PoseArray>& waypoints, const double& radius)
+{
+  std::vector<geometry_msgs::msg::PoseArray> filtered_waypoints;
+  for (auto waypoints : waypoints)
+  {
+    geometry_msgs::msg::PoseArray filtered_raster = crs_motion_planning::filterSingularityCylinder(waypoints, radius);
+    if (filtered_raster.poses.size() > 0)
+      filtered_waypoints.push_back(filtered_raster);
+  }
+  return filtered_waypoints;
+}
+
 double crs_motion_planning::calcPoseDist(const geometry_msgs::msg::Pose& waypoint1,
                                          const geometry_msgs::msg::Pose& waypoint2)
 {

--- a/crs_motion_planning/src/path_processing_utils.cpp
+++ b/crs_motion_planning/src/path_processing_utils.cpp
@@ -1224,3 +1224,25 @@ std::vector<double> crs_motion_planning::findRasterRotation(const geometry_msgs:
   return_vals.push_back(rotation_sum / distance_sum);
   return return_vals;
 }
+
+bool crs_motion_planning::checkJointState(const trajectory_msgs::msg::JointTrajectory& traj,
+                                          const sensor_msgs::msg::JointState joint_state,
+                                          const double tolerance)
+{
+  for (size_t i = 0; i < traj.joint_names.size(); ++i)
+  {
+    double target_traj_value = traj.points.front().positions[i];
+    for (size_t j = 0; j < joint_state.name.size(); ++j)
+    {
+      if (traj.joint_names[i] == joint_state.name[j])
+      {
+        double current_joint_value = joint_state.position[j];
+        if (current_joint_value >= target_traj_value - tolerance && current_joint_value <= target_traj_value + tolerance)
+          break;
+        else
+          return false;
+      }
+    }
+  }
+  return true;
+}

--- a/crs_motion_planning/src/path_processing_utils.cpp
+++ b/crs_motion_planning/src/path_processing_utils.cpp
@@ -1226,7 +1226,7 @@ std::vector<double> crs_motion_planning::findRasterRotation(const geometry_msgs:
   return return_vals;
 }
 
-bool crs_motion_planning::checkJointState(const trajectory_msgs::msg::JointTrajectory& traj,
+bool crs_motion_planning::checkStartState(const trajectory_msgs::msg::JointTrajectory& traj,
                                           const sensor_msgs::msg::JointState joint_state,
                                           const double tolerance)
 {

--- a/crs_motion_planning/src/path_processing_utils.cpp
+++ b/crs_motion_planning/src/path_processing_utils.cpp
@@ -1097,7 +1097,7 @@ crs_motion_planning::filterSingularityCylinder(const geometry_msgs::msg::PoseArr
   filtered_waypoints.header = waypoints.header;
   for (auto pose : waypoints.poses)
   {
-    double rad_point = sqrt(pow(pose.position.x,2) + pow(pose.position.y,2));
+    double rad_point = sqrt(pow(pose.position.x, 2) + pow(pose.position.y, 2));
     if (rad_point > radius)
     {
       filtered_waypoints.poses.push_back(pose);
@@ -1107,7 +1107,8 @@ crs_motion_planning::filterSingularityCylinder(const geometry_msgs::msg::PoseArr
 }
 
 std::vector<geometry_msgs::msg::PoseArray>
-crs_motion_planning::filterSingularityCylinder(const std::vector<geometry_msgs::msg::PoseArray>& waypoints, const double& radius)
+crs_motion_planning::filterSingularityCylinder(const std::vector<geometry_msgs::msg::PoseArray>& waypoints,
+                                               const double& radius)
 {
   std::vector<geometry_msgs::msg::PoseArray> filtered_waypoints;
   for (auto waypoints : waypoints)
@@ -1237,7 +1238,8 @@ bool crs_motion_planning::checkJointState(const trajectory_msgs::msg::JointTraje
       if (traj.joint_names[i] == joint_state.name[j])
       {
         double current_joint_value = joint_state.position[j];
-        if (current_joint_value >= target_traj_value - tolerance && current_joint_value <= target_traj_value + tolerance)
+        if (current_joint_value >= target_traj_value - tolerance &&
+            current_joint_value <= target_traj_value + tolerance)
           break;
         else
           return false;

--- a/crs_support/urdf/crs.urdf.xacro
+++ b/crs_support/urdf/crs.urdf.xacro
@@ -329,12 +329,12 @@
             </geometry>
             <origin rpy="0 0 0" xyz="-0.5 -1.1 1.38" />
         </collision>
-        <collision> <!-- Left Wall-->
+       <!-- <collision> Left Wall
             <geometry>
                 <box size="3.0 2.14 0.1" />
             </geometry>
             <origin rpy="0 0 0" xyz="-0.5 -1.1 -1.33" />
-        </collision>
+        </collision>-->
         <collision> Front Wall
             <geometry>
                 <box size="0.1 2.14 3.0" />
@@ -371,13 +371,13 @@
             </geometry>
             <origin rpy="0 0 0" xyz="-1.0 -2.135 0.0" />
         </collision>
-        <collision> <!-- Corner Bracket 1-->
+        <!--<collision> Corner Bracket 1
             <geometry>
                 <box size="1.25 0.12 1.25" />
             </geometry>
             <origin rpy="0 0.785 0" xyz="-2.06 -2.135 -1.33" />
-        </collision>
-        <collision> <!-- Corner Bracket 2-->
+        </collision>-->
+        <collision> Corner Bracket 2
             <geometry>
                 <box size="1.25 0.12 1.25" />
             </geometry>
@@ -399,7 +399,8 @@
     <joint name="${prefix}robot_base_joint" type="fixed">
         <parent link="${prefix}robot_stand" />
         <child link="${prefix}base" />
-        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.7977 " />
+<!--        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.7977 " />-->
+        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.2 " />
         <axis xyz="1 0 0"/>
         <limit effort="1.0" lower="-0.1" upper="1.9" velocity=".01" />
     </joint>

--- a/crs_support/urdf/crs.urdf.xacro
+++ b/crs_support/urdf/crs.urdf.xacro
@@ -400,7 +400,7 @@
         <parent link="${prefix}robot_stand" />
         <child link="${prefix}base" />
 <!--        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.7977 " /> Original position -->
-        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.2 " /> Middle position
+        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.153175 " /> Middle position
         <axis xyz="1 0 0"/>
         <limit effort="1.0" lower="-0.1" upper="1.9" velocity=".01" />
     </joint>

--- a/crs_support/urdf/crs.urdf.xacro
+++ b/crs_support/urdf/crs.urdf.xacro
@@ -329,12 +329,12 @@
             </geometry>
             <origin rpy="0 0 0" xyz="-0.5 -1.1 1.38" />
         </collision>
-       <!-- <collision> Left Wall
+        <collision> Left Wall
             <geometry>
                 <box size="3.0 2.14 0.1" />
             </geometry>
             <origin rpy="0 0 0" xyz="-0.5 -1.1 -1.33" />
-        </collision>-->
+        </collision>
         <collision> Front Wall
             <geometry>
                 <box size="0.1 2.14 3.0" />
@@ -371,12 +371,12 @@
             </geometry>
             <origin rpy="0 0 0" xyz="-1.0 -2.135 0.0" />
         </collision>
-        <!--<collision> Corner Bracket 1
+        <collision> Corner Bracket 1
             <geometry>
                 <box size="1.25 0.12 1.25" />
             </geometry>
             <origin rpy="0 0.785 0" xyz="-2.06 -2.135 -1.33" />
-        </collision>-->
+        </collision>
         <collision> Corner Bracket 2
             <geometry>
                 <box size="1.25 0.12 1.25" />
@@ -399,8 +399,8 @@
     <joint name="${prefix}robot_base_joint" type="fixed">
         <parent link="${prefix}robot_stand" />
         <child link="${prefix}base" />
-<!--        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.7977 " />-->
-        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.2 " />
+<!--        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.7977 " /> Original position -->
+        <origin rpy="-1.570796 -1.570796 0.0" xyz="-1.030659 -2.037406 0.2 " /> Middle position
         <axis xyz="1 0 0"/>
         <limit effort="1.0" lower="-0.1" upper="1.9" velocity=".01" />
     </joint>


### PR DESCRIPTION
- Fixed issue where cartesian controller could cause joint state to be off so now before freespace motions the joints are checked and a freespace plan is added if they aren't within tolerance

- Updated base positions based on measured values from WSU

- Cleaned up process planner to avoid going back to start pose before each media change pose

- Fixed bug that caused media change pose to change if more than 1 because the target position for the goal to the freespace planning server got overwritten and not reset