### PR TITLE
Singularity waypoint pruning

### DIFF
--- a/crs_application/include/crs_application/common/config.h
+++ b/crs_application/include/crs_application/common/config.h
@@ -106,6 +106,7 @@ struct PartRegistrationConfig
   std::array<double, 6> simulation_pose;
   double waypoint_edge_buffer;
   double reachable_radius;
+  double singularity_radius;
 };
 
 struct PartReworkConfig

--- a/crs_application/src/common/config.cpp
+++ b/crs_application/src/common/config.cpp
@@ -92,6 +92,7 @@ static const std::string PART_FILE = "part_file";
 static const std::string TOOLPATH_FILE = "toolpath_file";
 static const std::string TOOLPATH_EDGE_BUFFER = "toolpath_edge_buffer";
 static const std::string REACHABLE_RADIUS = "reachable_radius";
+static const std::string SINGULARITY_RADIUS = "singularity_radius";
 }  // namespace part_registration
 
 namespace part_rework
@@ -434,6 +435,7 @@ boost::optional<PartRegistrationConfig> parse(YAML::Node& config, std::string& e
     Node root_node = config[TOP_LEVEL];
     cfg.waypoint_edge_buffer = 0.0;
     cfg.reachable_radius = 5.0;
+    cfg.singularity_radius = -0.1;
 
     if (hasFields(root_node, TOP_LEVEL, { TOOLPATH_EDGE_BUFFER }))
     {
@@ -449,6 +451,17 @@ boost::optional<PartRegistrationConfig> parse(YAML::Node& config, std::string& e
     if (hasFields(root_node, TOP_LEVEL, { REACHABLE_RADIUS }))
     {
       cfg.reachable_radius = root_node[REACHABLE_RADIUS].as<double>();
+    }
+    else
+    {
+      err_msg = boost::str(boost::format("Failed to find optional fields  in %s yaml, using defaults") %
+                           typeid(PartRegistrationConfig).name());
+      RCLCPP_WARN(CONFIG_LOGGER, "%s", err_msg.c_str());
+    }
+
+    if (hasFields(root_node, TOP_LEVEL, { SINGULARITY_RADIUS }))
+    {
+      cfg.singularity_radius = root_node[SINGULARITY_RADIUS].as<double>();
     }
     else
     {

--- a/crs_application/src/task_managers/motion_planning_manager.cpp
+++ b/crs_application/src/task_managers/motion_planning_manager.cpp
@@ -435,10 +435,20 @@ common::ActionResult MotionPlanningManager::planMediaChanges()
     }
     media_change_plan.start_traj = opt.get();
 
+    const trajectory_msgs::msg::JointTrajectory& next_traj = result_.process_plans[i + 1].process_motions.front();
+    if (!next_traj.points.empty())
+    {
+      req->goal_position.position = next_traj.points.front().positions;
+      req->goal_position.name = next_traj.joint_names;
+    }
+    else
+    {
+      req->goal_position.position = media_change_plan.start_traj.points.front().positions;
+      req->goal_position.name = media_change_plan.start_traj.joint_names;
+    }
+
     // free space motion planning for return move
     req->start_position.position = media_change_plan.start_traj.points.back().positions;
-    req->goal_position.position = media_change_plan.start_traj.points.front().positions;
-    req->goal_position.name = media_change_plan.start_traj.joint_names;
     opt = planFreeSpace("RETURN TO PROCESS", req);
     if (!opt.is_initialized())
     {

--- a/crs_application/src/task_managers/part_registration_manager.cpp
+++ b/crs_application/src/task_managers/part_registration_manager.cpp
@@ -302,13 +302,15 @@ common::ActionResult PartRegistrationManager::applyTransform()
   }
 
   cropped_raster_strips = crs_motion_planning::removeEdgeWaypoints(original_rasters, config_->waypoint_edge_buffer);
-  std::vector<geometry_msgs::msg::PoseArray> organized_rasters =
-      crs_motion_planning::organizeRasters(cropped_raster_strips);
   std::vector<geometry_msgs::msg::PoseArray> transformed_waypoints =
-      crs_motion_planning::transformWaypoints(organized_rasters, transform);
+      crs_motion_planning::transformWaypoints(cropped_raster_strips, transform);
+  std::vector<geometry_msgs::msg::PoseArray> singularity_filtered =
+      crs_motion_planning::filterSingularityCylinder(transformed_waypoints, config_->singularity_radius);
+  std::vector<geometry_msgs::msg::PoseArray> organized_rasters =
+      crs_motion_planning::organizeRasters(singularity_filtered);
   std::vector<geometry_msgs::msg::PoseArray> reachable_transformed_waypoints;
   crs_motion_planning::filterReachabilitySphere(
-      transformed_waypoints, config_->reachable_radius, reachable_transformed_waypoints);
+      organized_rasters, config_->reachable_radius, reachable_transformed_waypoints);
   std::vector<geometry_msgs::msg::PoseArray> reachable_waypoints =
       crs_motion_planning::transformWaypoints(reachable_transformed_waypoints, transform, true);
 

--- a/crs_motion_planning/include/crs_motion_planning/path_planning_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_planning_utils.h
@@ -195,8 +195,10 @@ struct pathPlanningResults
   std::vector<trajectory_msgs::msg::JointTrajectory> ompl_trajectories;
   std::vector<trajectory_msgs::msg::JointTrajectory> final_freespace_trajectories;
 
-  std::vector<trajectory_msgs::msg::JointTrajectory> ompl_start_end_trajectories;
-  std::vector<trajectory_msgs::msg::JointTrajectory> final_start_end_trajectories;
+  trajectory_msgs::msg::JointTrajectory ompl_start_trajectory;
+  trajectory_msgs::msg::JointTrajectory ompl_end_trajectory;
+  trajectory_msgs::msg::JointTrajectory final_start_trajectory;
+  trajectory_msgs::msg::JointTrajectory final_end_trajectory;
 
   std::vector<trajectory_msgs::msg::JointTrajectory> final_trajectories;
   std::string msg_out;

--- a/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
+++ b/crs_motion_planning/include/crs_motion_planning/path_processing_utils.h
@@ -278,8 +278,8 @@ bool filterReachabilitySphere(const std::vector<geometry_msgs::msg::PoseArray>& 
 /// \brief filterSingularityCylinder Removes any points inside cylinder coming from robot base
 /// \return filtered points
 ///
-geometry_msgs::msg::PoseArray filterSingularityCylinder(const geometry_msgs::msg::PoseArray& waypoints,
-                                                        const double& radius);
+std::vector<geometry_msgs::msg::PoseArray> filterSingularityCylinder(const geometry_msgs::msg::PoseArray& waypoints,
+                                                                     const double& radius);
 
 ///
 /// \brief filterSingularityCylinder Removes any points inside cylinder coming from robot base

--- a/crs_motion_planning/src/motion_planning_server.cpp
+++ b/crs_motion_planning/src/motion_planning_server.cpp
@@ -210,7 +210,7 @@ private:
         }
         std::vector<double> last_pose = returned_plans[last_success_i].process_motions.back().points.back().positions;
         std::vector<std::string> last_joint_names = returned_plans[last_success_i].process_motions.back().joint_names;
-        motion_planner_config->use_start = true;
+        motion_planner_config->use_start = false;
         motion_planner_config->start_pose =
             std::make_shared<tesseract_motion_planners::JointWaypoint>(last_pose, last_joint_names);
         returned_plans[last_success_i].end.points.clear();
@@ -274,13 +274,13 @@ private:
       // Store trajectories for service response
       trajopt_trajectories = path_plan_results->final_trajectories;
       crs_msgs::msg::ProcessMotionPlan resulting_process;
-      if (path_plan_results->final_start_end_trajectories.size() > 0)
+      if (path_plan_results->final_start_trajectory.points.size() > 0)
       {
-        resulting_process.start = path_plan_results->final_start_end_trajectories[0];
+        resulting_process.start = path_plan_results->final_start_trajectory;
       }
-      if (path_plan_results->final_start_end_trajectories.size() > 1)
+      if (path_plan_results->final_end_trajectory.points.size() > 0)
       {
-        resulting_process.end = path_plan_results->final_start_end_trajectories[1];
+        resulting_process.end = path_plan_results->final_end_trajectory;
       }
       resulting_process.free_motions = path_plan_results->final_freespace_trajectories;
       resulting_process.process_motions = path_plan_results->final_raster_trajectories;

--- a/crs_motion_planning/src/path_planning_utils.cpp
+++ b/crs_motion_planning/src/path_planning_utils.cpp
@@ -277,6 +277,9 @@ bool crsMotionPlanner::generateDescartesSeed(const geometry_msgs::msg::PoseArray
 
   descartes_light::SolverD graph_builder(kin_interface->dof());
 
+  if (sampler_result.empty())
+    return false;
+
   if (!graph_builder.build(std::move(sampler_result), std::move(timing_constraint), std::move(edge_eval)))
   {
     failed_edges = graph_builder.getFailedEdges();
@@ -1043,8 +1046,8 @@ bool crsMotionPlanner::generateFreespacePlans(pathPlanningResults::Ptr& results)
       curr_joint_traj = new_traj;
     }
     RCLCPP_INFO(logger_, "STORING TRAJECTORIES");
-    results->ompl_start_end_trajectories.push_back(ompl_joint_traj);
-    results->final_start_end_trajectories.push_back(curr_joint_traj);
+    results->ompl_start_trajectory = ompl_joint_traj;
+    results->final_start_trajectory = curr_joint_traj;
     results->final_trajectories.push_back(curr_joint_traj);
   }
   RCLCPP_INFO(logger_, "STORING FIRST RASTER");
@@ -1169,8 +1172,8 @@ bool crsMotionPlanner::generateFreespacePlans(pathPlanningResults::Ptr& results)
       curr_joint_traj = new_traj;
     }
     RCLCPP_INFO(logger_, "STORING TRAJECTORIES");
-    results->ompl_start_end_trajectories.push_back(ompl_joint_traj);
-    results->final_start_end_trajectories.push_back(curr_joint_traj);
+    results->ompl_end_trajectory = ompl_joint_traj;
+    results->final_end_trajectory = curr_joint_traj;
     results->final_trajectories.push_back(curr_joint_traj);
   }
 


### PR DESCRIPTION
Remove points that could potentially cause singularity issues.

- New optional variable in crs.yaml in part_registration of singularity_radius: (double) that sets the radius around the robot base, in x and y relative to the base frame of the robot, of points to be removed.

- If a point is removed in the middle of a raster it splits it into two rasters

- The rasters are re-ordered after the splitting occurs to get better path transitions

Improved planning order so that after media change it goes directly to the start of the next process

Fixed an error in Descartes planning call that wasn't seen until now and only showed up in specific, rare, situations