### PR TITLE
Variable minimum raster length

### DIFF
--- a/crs_motion_planning/src/motion_planning_server.cpp
+++ b/crs_motion_planning/src/motion_planning_server.cpp
@@ -164,6 +164,8 @@ private:
     motion_planner_config->tesseract_local = tesseract_local_;
 
     // Setup planner config with requested process planner service request data
+    if (request->accept_all_rasters)
+      motion_planner_config->minimum_raster_length = 0;
     motion_planner_config->tcp_frame = request->tool_link;
     motion_planner_config->approach_distance = request->approach_dist;
     motion_planner_config->retreat_distance = request->retreat_dist;

--- a/crs_msgs/srv/PlanProcessMotions.srv
+++ b/crs_msgs/srv/PlanProcessMotions.srv
@@ -7,6 +7,7 @@ float64 retreat_dist
 float64 tool_speed
 float64 target_force
 crs_msgs/ToolProcessPath[] process_paths
+bool accept_all_rasters
 
 ---
 crs_msgs/ProcessMotionPlan[] plans	# The motion plans											


### PR DESCRIPTION
Added field in PlanProcessMotions.srv that will make minimum raster length 0 if set to true

Added check in motion planning server for this field

Needs to be incorporated to the main applications

This is committed on top of PR #100 